### PR TITLE
Changing back to 'Getting started'

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -55,7 +55,7 @@ class Nav extends Component {
                 href="#responsive-header"
                 css={tw`block mt-4 lg:inline-block lg:mt-0 mr-6`}
               >
-                Recovery Resources
+                Getting started
               </a>
               <a
                 href="#responsive-header"


### PR DESCRIPTION
After aligning on the content strategy for MVP, I wanted to switch "recovery resources" back to "Getting started." Also, this is my first commit on federalist so going to create a pull request in case I'm doing it incorrectly! :)