### PR TITLE
Remove URLSearchParams

### DIFF
--- a/src/actions/facilities.js
+++ b/src/actions/facilities.js
@@ -1,3 +1,4 @@
+import qs from 'qs';
 import API, { buildParams } from '../utils/api';
 
 export const RECEIVE_FACILITIES_BEGIN = 'RECEIVE_FACILITIES_BEGIN';
@@ -28,8 +29,14 @@ export function handleReceiveFacilities(query) {
     dispatch(receiveFacilitiesBegin());
 
     const params = buildParams(query);
+    const options = {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      data: qs.stringify(params),
+      url: '/listing'
+    };
 
-    return API.post('/listing', params)
+    return API(options)
       .then(response => {
         if (response.data) {
           dispatch(receiveFacilitiesSucess(response.data));

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -6,25 +6,64 @@ export default axios.create({
 });
 
 export const buildParams = query => {
-  const { type, location, distance, page, language, ...rest } = query;
-  const codes = Object.values(rest);
-  const hasCodes = codes.length >= 1;
-  const params = new URLSearchParams();
+  const initialValues = {
+    sType: 'BOTH',
+    sCodes: '',
+    pageSize: 10,
+    page: 1,
+    sort: 0
+  };
 
-  params.append('sType', 'BOTH');
-  hasCodes && params.append('sCodes', codes.toString());
-  language && params.append('sLanguages', language);
-  params.append(
-    'sAddr',
-    location && `${location.location.lat}, ${location.location.lng}`
-  );
-  if (distance !== 'All') {
-    params.append('limitType', 2);
-    params.append('limitValue', distance || 16093.4);
+  const params = Object.entries(query).reduce((memo, [key, value]) => {
+    if (key === 'distance' && value !== 'All') {
+      return {
+        ...memo,
+        limitType: 2,
+        limitValue: 16093.4
+      };
+    }
+
+    if (key === 'languages') {
+      return {
+        ...memo,
+        sLanguages: value
+      };
+    }
+
+    if (key === 'location') {
+      return {
+        ...memo,
+        sAddr: `${value.location.lat}, ${value.location.lng}`
+      };
+    }
+
+    if (key === 'page') {
+      return {
+        ...memo,
+        page: value
+      };
+    }
+
+    if (key === 'type' && value === 'Intake') {
+      return memo;
+    }
+
+    return {
+      ...memo,
+      sCodes:
+        memo.sCodes
+          .split(',')
+          .filter(v => !!v)
+          .concat(value)
+          .join() || undefined
+    };
+  }, initialValues);
+
+  if (!params.sCodes) {
+    const { sCodes, ...finalParams } = params;
+
+    return finalParams;
   }
-  params.append('pageSize', 10);
-  params.append('page', page || 1);
-  params.append('sort', 0);
 
   return params;
 };

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -36,6 +36,8 @@ export const payment = [
 ];
 
 export const type = [
+  { value: 'Intake', label: 'Intake assessment offered' },
+  { value: 'ISC', label: 'Interim services for clients available' },
   { value: 'DT', label: 'Detoxification' },
   { value: 'OP', label: 'Outpatient' },
   { value: 'HI', label: 'Hospital inpatient' },


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/14
Fixes https://github.com/18F/samhsa-prototype/issues/17

Refactors the way the params are prepared to be sent to the endpoint, no longer relying on URLSearchParams which is not cross browser compatible.

Also adds additional options to the `Type of Care` filter.