### PR TITLE
Handle 100+ distance properly in new api reducer

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -17,10 +17,10 @@ export const buildParams = query => {
   };
 
   const params = Object.entries(query).reduce((memo, [key, value]) => {
-    if (key === 'distance' && value !== 'All') {
+    if (key === 'distance') {
       return {
         ...memo,
-        limitValue: value
+        limitValue: value !== 'All' ? value : memo.limitValue
       };
     }
 


### PR DESCRIPTION
The `All` value for distance was falling through the reducer and getting added to `sCodes`, this makes sure it is handled properly.