### PR TITLE
Add content page template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11502,6 +11502,14 @@
         "tiny-warning": "^1.0.0"
       }
     },
+    "react-router-hash-link": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-1.2.1.tgz",
+      "integrity": "sha512-ddkCtmk/JwMmuU087TGShQHYyNjsJ+/9CTyuVdvvKf6ACgqk2Ma9ndX2xogo7WWmyq9AjuziBm5bmJ12zBxtsQ==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-scripts": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-paginate": "^6.3.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.0",
+    "react-router-hash-link": "^1.2.1",
     "react-scripts": "3.0.1",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import Header from './Header';
 import Home from './Home';
 import Results from './Results';
 import Details from './Details';
+import Page from './Page';
 import NoMatch from './NoMatch';
 import Footer from './Footer';
 
@@ -26,6 +27,7 @@ class App extends Component {
           <Route exact path="/" component={Home} />
           <Route path="/results" component={Results} />
           <Route path="/details" component={Details} />
+          <Route path="/content/:pageId" component={Page} />
           <Route component={NoMatch} />
         </Switch>
         <Footer />

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { handleReceiveFacilities } from '../actions/facilities';
 import 'styled-components/macro';
 import tw from 'tailwind.macro';
@@ -9,16 +9,19 @@ import Button from './Form/Button';
 
 const content = [
   {
+    slug: 'understanding-addiction',
     heading: 'Understanding addiction',
     body:
       'Substance use and mental health problems are treatable, and help is available.'
   },
   {
+    slug: 'treatment-options',
     heading: 'Treatment options',
     body:
       'Find out more about different types of treatment and finding a good fit.'
   },
   {
+    slug: 'getting-to-recovery',
     heading: 'Getting to recovery',
     body: 'Know what to expect and how to find support on the road to recovery.'
   }
@@ -41,7 +44,8 @@ class Home extends Component {
         <div className="container" css={tw`mx-auto text-center mb-10`}>
           <h2 css={tw`text-3xl lg:text-5xl font-light`}>Find help near you</h2>
           <span>
-            Quickly find providers who treat substance use disorders and addiction
+            Quickly find providers who treat substance use disorders and
+            addiction
           </span>
         </div>
         <Homepage onSubmit={this.submit} />
@@ -53,9 +57,9 @@ class Home extends Component {
               </h3>
             </div>
             <div css={tw`flex flex-wrap -mx-2`}>
-              {content.map((card, index) => (
+              {content.map(card => (
                 <div
-                  key={index}
+                  key={card.slug}
                   css={tw`flex w-full lg:w-1/3 px-2 mb-6 lg:mb-0 `}
                 >
                   <div
@@ -63,7 +67,9 @@ class Home extends Component {
                   >
                     <h4 css={tw`text-xl mb-4 leading-tight`}>{card.heading}</h4>
                     <p css={tw`flex-auto  mb-6 text-sm`}>{card.body}</p>
-                    <Button outline>Learn more</Button>
+                    <Link to={`/content/${card.slug}`}>
+                      <Button outline>Learn more</Button>
+                    </Link>
                   </div>
                 </div>
               ))}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { withRouter, Link } from 'react-router-dom';
+import { HashLink } from 'react-router-hash-link';
+import 'styled-components/macro';
+import tw from 'tailwind.macro';
+import NoMatch from './NoMatch';
+import { convertToSlug } from '../utils/misc';
+import { topics, lipsum } from '../utils/topics';
+
+class Page extends Component {
+  render() {
+    const { match } = this.props;
+    const topic = topics.find(({ id }) => id === match.params.pageId);
+
+    if (!topic) {
+      return <NoMatch />;
+    }
+
+    return (
+      <div className="container">
+        <div css={tw`flex flex-wrap -mx-6`}>
+          <div css={tw`w-full lg:w-1/3 px-6 mb-6 lg:mb-0`}>
+            <p css={tw`mb-2 text-sm`}>Browse all recovery resources</p>
+            <ul>
+              {topics.map(({ name, id, subTopics }) => (
+                <li key={id} css={tw`mb-4`}>
+                  <Link to={id} css={tw`text-gray-900 font-bold text-xl`}>
+                    {name}
+                  </Link>
+                  {id === match.params.pageId && (
+                    <ul css={tw`my-2`}>
+                      {subTopics.map(({ name, body }) => (
+                        <li key={convertToSlug(name)} css={tw`mb-3`}>
+                          <HashLink
+                            to={`#${convertToSlug(name)}`}
+                            css={tw`text-gray-700 border-l-4 border-gray-200 px-2 py-1`}
+                          >
+                            {name}
+                          </HashLink>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div css={tw`w-full lg:w-2/3 px-6 mb-6`}>
+            <h1 css={tw`font-bold lg:text-5xl`}>{topic.name}</h1>
+            <p css={tw`text-xl font-light mb-4`}>{topic.description}</p>
+            {topic.subTopics.map(({ name, body }) => (
+              <div key={convertToSlug(name)}>
+                <h2 id={convertToSlug(name)} css={tw`font-bold`}>
+                  {name}
+                </h2>
+                <p css={tw`mb-4`}>{body || lipsum}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default withRouter(Page);

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -5,12 +5,12 @@ import 'styled-components/macro';
 import tw from 'tailwind.macro';
 import NoMatch from './NoMatch';
 import { convertToSlug } from '../utils/misc';
-import { topics, lipsum } from '../utils/topics';
+import topics, { lipsum } from '../utils/topics';
 
 class Page extends Component {
   render() {
     const { match } = this.props;
-    const topic = topics.find(({ id }) => id === match.params.pageId);
+    const topic = topics().find(({ id }) => id === match.params.pageId);
 
     if (!topic) {
       return <NoMatch />;
@@ -22,7 +22,7 @@ class Page extends Component {
           <div css={tw`w-full lg:w-1/3 px-6 mb-6 lg:mb-0`}>
             <p css={tw`mb-2 text-sm`}>Browse all recovery resources</p>
             <ul>
-              {topics.map(({ name, id, subTopics }) => (
+              {topics().map(({ name, id, subTopics }) => (
                 <li key={id} css={tw`mb-4`}>
                   <Link to={id} css={tw`text-gray-900 font-bold text-xl`}>
                     {name}
@@ -53,7 +53,7 @@ class Page extends Component {
                 <h2 id={convertToSlug(name)} css={tw`font-bold`}>
                   {name}
                 </h2>
-                <p css={tw`mb-4`}>{body || lipsum}</p>
+                <div css={tw`mb-4`}>{body || lipsum}</div>
               </div>
             ))}
           </div>

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,0 +1,5 @@
+export const convertToSlug = string =>
+  string
+    .toLowerCase()
+    .replace(/ /g, '-')
+    .replace(/[^\w-]+/g, '');

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -1,0 +1,93 @@
+export const topics = [
+  {
+    name: 'Understanding addiction',
+    id: 'understanding-addiction',
+    description:
+      'Substance use and mental health problems are treatable, and help is available.',
+    subTopics: [
+      {
+        name: 'Why is it hard?',
+        body: ''
+      },
+      {
+        name: 'How do I stop?',
+        body: ''
+      },
+      {
+        name: 'Building a support team',
+        body: ''
+      },
+      {
+        name: 'What is a SUD?',
+        body: ''
+      },
+      {
+        name: 'Why are some people affected?',
+        body: ''
+      }
+    ]
+  },
+  {
+    name: 'Treatment Options',
+    id: 'treatment-options',
+    description:
+      'Learn how to find quality treatment, and ask the right questions of providers and insurance companies.',
+    subTopics: [
+      {
+        name: 'Who provides treatment?',
+        body: ''
+      },
+      {
+        name: 'What happens first?',
+        body: ''
+      },
+      {
+        name: 'What types of treatment are there?',
+        body: ''
+      },
+      {
+        name: 'What happens in treatment?',
+        body: ''
+      },
+      {
+        name: 'Three steps to accessing care',
+        body: ''
+      },
+      {
+        name: 'Five signs of quality treatment',
+        body: ''
+      }
+    ]
+  },
+  {
+    name: 'Getting to recovery',
+    id: 'getting-to-recovery',
+    description:
+      'Know what to expect and how to find support on the road to recovery.',
+    subTopics: [
+      {
+        name: 'Long-term recovery',
+        body: ''
+      },
+      {
+        name: 'Helping someone through recovery',
+        body: ''
+      },
+      {
+        name: 'Basic living needs',
+        body: ''
+      },
+      {
+        name: 'For caregivers',
+        body: ''
+      },
+      {
+        name: 'What is family therapy?',
+        body: ''
+      }
+    ]
+  }
+];
+
+export const lipsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec egestas augue non felis gravida, in efficitur sapien viverra. Mauris dapibus ultrices libero, at convallis tortor pellentesque a. Sed vestibulum nisi eu tristique laoreet. Nullam iaculis nisi metus, at aliquet quam dignissim ac. Suspendisse quis justo eget sem vulputate euismod. Duis a egestas dolor, vitae interdum nulla. Fusce semper nunc ex, sit amet mattis ipsum finibus ac. Aliquam congue, orci varius faucibus elementum, nibh neque gravida odio, id aliquet purus tellus a diam. Interdum et malesuada fames ac ante ipsum primis in faucibus. Vestibulum tempor augue sit amet lectus hendrerit, et ullamcorper nisi tristique. Duis fermentum aliquet nibh ac consectetur. Quisque nulla orci, finibus in tellus eu, pharetra viverra erat. Donec lobortis tristique aliquam. Aliquam in mollis dui. Suspendisse a lacus ac tellus auctor pulvinar at nec metus.';

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -1,4 +1,9 @@
-export const topics = [
+import React from 'react';
+import { Link } from 'react-router-dom';
+import 'styled-components/macro';
+import tw from 'tailwind.macro';
+
+export default () => [
   {
     name: 'Understanding addiction',
     id: 'understanding-addiction',
@@ -7,7 +12,11 @@ export const topics = [
     subTopics: [
       {
         name: 'Why is it hard?',
-        body: ''
+        body: (
+          <p css={tw`block`}>
+            <strong>This</strong> is a test <Link to="/">link</Link>
+          </p>
+        )
       },
       {
         name: 'How do I stop?',


### PR DESCRIPTION
Adds a new view for content based pages. As it stands now, the content is pulled out into `utils/topics.js` - and if the `body` of a `subTopic` is empty its just filled with lorem ipsum. The way all of this works will need to be refined so that we can support things like inline formatting and links within the content, but this helps gets some of the pieces in place.

I also linked up the homepage cards to the corresponding pages for the time being.

Preview: https://cg-efcd7c90-b365-4336-8b87-6174f1975c99.app.cloud.gov/preview/18f/samhsa-prototype/bh-content-page/