### PR TITLE
Updates based on team audit session

### DIFF
--- a/src/components/Form/Filters.js
+++ b/src/components/Form/Filters.js
@@ -73,7 +73,7 @@ export class Filters extends Component {
               label="Location"
               component={Location}
               name="location"
-              placeholder="City, state, or zip code"
+              placeholder="City or zip code"
               format={v => (v ? v : '')}
             />
           </div>

--- a/src/components/Form/Homepage.js
+++ b/src/components/Form/Homepage.js
@@ -31,7 +31,7 @@ class Homepage extends Component {
               label="Location"
               component={Location}
               name="location"
-              placeholder="City, state, or zip code"
+              placeholder="City or zip code"
             />
           </div>
           <div css={tw`flex items-end w-full lg:w-1/3 px-3 mb-6 lg:mb-0`}>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -44,8 +44,9 @@ class Home extends Component {
         <div className="container" css={tw`mx-auto text-center mb-10`}>
           <h2 css={tw`text-3xl lg:text-5xl font-light`}>Find help near you</h2>
           <span>
-            Quickly find providers who treat substance use disorders and
-            addiction
+            Quickly find providers who treat{' '}
+            <strong>substance use disorders</strong> and{' '}
+            <strong>addiction</strong>
           </span>
         </div>
         <div css={tw`max-w-3xl mx-auto mb-10 px-6`}>


### PR DESCRIPTION
- Removed reference to state in search box placeholder text (assuming these are the only references?)
- Made substance use and addiction bold in 'Find help' subtitle (Nick's suggestion for now, based on our ask about how to make that more prominent)
