### PR TITLE
Use enableReinitialize option on filters form

### DIFF
--- a/src/actions/facilities.js
+++ b/src/actions/facilities.js
@@ -5,6 +5,7 @@ import ReactGA from 'react-ga';
 export const RECEIVE_FACILITIES_BEGIN = 'RECEIVE_FACILITIES_BEGIN';
 export const RECEIVE_FACILITIES_SUCCESS = 'RECEIVE_FACILITIES_SUCCESS';
 export const RECEIVE_FACILITIES_FAILURE = 'RECEIVE_FACILITIES_FAILURE';
+export const DESTROY_FACILITIES = 'DESTROY_FACILITIES';
 
 const trackSearchResults = (params, results) => {
   ReactGA.event({
@@ -31,6 +32,12 @@ export const receiveFacilitiesSucess = data => {
 export const receiveFacilitiesFailure = error => {
   return {
     type: RECEIVE_FACILITIES_FAILURE
+  };
+};
+
+export const destroyFacilities = () => {
+  return {
+    type: DESTROY_FACILITIES
   };
 };
 

--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -1,6 +1,5 @@
 export const RESET_ADVANCED_FILTERS = 'RESET_ADVANCED_FILTERS';
 export const RESET_ALL_FILTERS = 'RESET_ALL_FILTERS';
-export const DESTROY_FILTERS = 'DESTROY_FILTERS';
 
 export const resetAllFilters = () => ({
   type: RESET_ALL_FILTERS
@@ -8,8 +7,4 @@ export const resetAllFilters = () => ({
 
 export const resetAdvancedFilters = () => ({
   type: RESET_ADVANCED_FILTERS
-});
-
-export const destroyFilters = () => ({
-  type: DESTROY_FILTERS
 });

--- a/src/components/Form/Filters.js
+++ b/src/components/Form/Filters.js
@@ -278,6 +278,7 @@ export default connect(
 )(
   reduxForm({
     form: 'filters',
+    enableReinitialize: true,
     destroyOnUnmount: false
   })(withSizes(mapSizesToProps)(Filters))
 );

--- a/src/components/Form/Filters.js
+++ b/src/components/Form/Filters.js
@@ -11,7 +11,6 @@ import { Location, Select } from '../Input';
 import Button from './Button';
 import { resetAdvancedFilters, resetAllFilters } from '../../actions/filters';
 import { handleReceiveFacilities } from '../../actions/facilities';
-import { initialFilterState } from '../../plugins/filters';
 
 const Row = styled.div`
   ${tw`w-full mb-6`}
@@ -252,7 +251,6 @@ const mapStateToProps = state => {
 
   return {
     initialValues: {
-      ...initialFilterState,
       ...locationValue
     },
     location: locationValue && locationValue.location,

--- a/src/components/Form/Homepage.js
+++ b/src/components/Form/Homepage.js
@@ -5,7 +5,6 @@ import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import Button from './Button';
 import { Location } from '../Input';
-import { initialFilterState } from '../../plugins/filters';
 import { destroyFacilities } from '../../actions/facilities';
 
 const Form = styled.form`
@@ -59,13 +58,17 @@ const mapStateToProps = state => {
   const values = getFormValues('homepage')(state);
 
   return {
+    initialValues: {
+      ...getFormValues('filters')(state)
+    },
     location: values && values.location
   };
 };
 
 export { Homepage };
-export default reduxForm({
-  form: 'homepage',
-  initialValues: initialFilterState,
-  destroyOnUnmount: false
-})(connect(mapStateToProps)(Homepage));
+export default connect(mapStateToProps)(
+  reduxForm({
+    form: 'homepage',
+    destroyOnUnmount: false
+  })(Homepage)
+);

--- a/src/components/Form/Homepage.js
+++ b/src/components/Form/Homepage.js
@@ -59,7 +59,7 @@ const mapStateToProps = state => {
 
   return {
     initialValues: {
-      ...getFormValues('filters')(state)
+      ...state.form.filters
     },
     location: values && values.location
   };

--- a/src/components/Form/Homepage.js
+++ b/src/components/Form/Homepage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Field, reduxForm, getFormValues } from 'redux-form';
+import { Field, reduxForm, getFormValues, reset } from 'redux-form';
 import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import Button from './Button';
@@ -14,8 +14,12 @@ const Form = styled.form`
 
 class Homepage extends Component {
   componentDidMount() {
-    const { dispatch } = this.props;
-    dispatch(destroyFacilities());
+    const { dispatch, location } = this.props;
+
+    if (location) {
+      dispatch(reset('homepage'));
+      dispatch(destroyFacilities());
+    }
   }
 
   handleSubmit = submitEvent => {
@@ -62,5 +66,6 @@ const mapStateToProps = state => {
 export { Homepage };
 export default reduxForm({
   form: 'homepage',
-  initialValues: initialFilterState
+  initialValues: initialFilterState,
+  destroyOnUnmount: false
 })(connect(mapStateToProps)(Homepage));

--- a/src/components/Form/Homepage.js
+++ b/src/components/Form/Homepage.js
@@ -5,8 +5,8 @@ import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import Button from './Button';
 import { Location } from '../Input';
-import { destroyFilters } from '../../actions/filters';
 import { initialFilterState } from '../../plugins/filters';
+import { destroyFacilities } from '../../actions/facilities';
 
 const Form = styled.form`
   ${tw`mb-10`}
@@ -15,8 +15,7 @@ const Form = styled.form`
 class Homepage extends Component {
   componentDidMount() {
     const { dispatch } = this.props;
-
-    dispatch(destroyFilters());
+    dispatch(destroyFacilities());
   }
 
   handleSubmit = submitEvent => {

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -1,8 +1,4 @@
-import {
-  RESET_ADVANCED_FILTERS,
-  RESET_ALL_FILTERS,
-  DESTROY_FILTERS
-} from '../actions/filters';
+import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
 
 export const initialFilterState = {
   distance: 16093.4

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -1,6 +1,6 @@
 import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
 
-export const initialFilterState = {
+const initialFilterState = {
   distance: 16093.4
 };
 
@@ -19,7 +19,7 @@ const resetFilters = values => {
 };
 
 export default {
-  filters(state, action) {
+  filters(state = initialFilterState, action) {
     switch (action.type) {
       case RESET_ADVANCED_FILTERS: {
         return {

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -37,9 +37,6 @@ export default {
           values: { ...initialFilterState, location: state.values.location }
         };
       }
-      case DESTROY_FILTERS: {
-        return undefined;
-      }
       default:
         return state;
     }

--- a/src/reducers/facilities.js
+++ b/src/reducers/facilities.js
@@ -1,7 +1,8 @@
 import {
   RECEIVE_FACILITIES_BEGIN,
   RECEIVE_FACILITIES_SUCCESS,
-  RECEIVE_FACILITIES_FAILURE
+  RECEIVE_FACILITIES_FAILURE,
+  DESTROY_FACILITIES
 } from '../actions/facilities';
 
 const initialState = {
@@ -28,6 +29,8 @@ export default function facilities(state = initialState, action) {
         loading: false,
         data: {}
       };
+    case DESTROY_FACILITIES:
+      return initialState;
     default:
       return state;
   }


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/89

Alternate approach for location bug fixed in https://github.com/18F/samhsa-prototype/pull/94. Also ensures that facilities store is cleared when filter form is reinitialized so results and filters do not become out of sync.