### PR TITLE
Fix for map link

### DIFF
--- a/src/components/Map/InfoWindowText.js
+++ b/src/components/Map/InfoWindowText.js
@@ -26,7 +26,7 @@ export const InfoWindowText = props => {
         <Link
           to={{
             pathname: '/details',
-            state: selectedPlace.details
+            state: { id: selectedPlace.details.frid }
           }}
           css={tw`block`}
         >


### PR DESCRIPTION
This was left out of https://github.com/18F/samhsa-prototype/pull/71 and is required for the links on the map popups to properly route to the detail page.