### PR TITLE
Capture age in filters reducer

### DIFF
--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -1,10 +1,11 @@
 import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
+import { ADVANCED_FILTERS, DEFAULT_DISTANCE } from '../utils/constants';
 
 const initialFilterState = {
-  distance: 16093.4
+  distance: DEFAULT_DISTANCE
 };
 
-const advancedFilters = ['language', 'VET', 'GL', 'mat'];
+const advancedFilters = ADVANCED_FILTERS;
 const resetFilters = values => {
   return Object.entries(values).reduce((memo, [key, value]) => {
     if (advancedFilters.includes(key)) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,1 +1,2 @@
-export const GOOGLE_API_KEY = 'AIzaSyDPni-q0MMWdPAGrlv7wS8AYgfmcGUo4as';
+export const ADVANCED_FILTERS = ['age', 'language', 'VET', 'GL', 'mat'];
+export const DEFAULT_DISTANCE = 16093.4;

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -1,7 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import 'styled-components/macro';
-import tw from 'tailwind.macro';
 
 export default () => [
   {


### PR DESCRIPTION
This is required in order to clear the value upon hiding the advanced filters. Also moved the advanced filter array and default distance to constants file so they are more visible.