### PR TITLE
Updated 'What to expect' and other content changes

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -73,7 +73,7 @@ const Card = props => {
       </div>
       <p css={tw`mb-4`}>
         <span css={tw`font-semibold`}>Type of care:</span>{' '}
-        <span>{services[1].f3}</span>
+        <span>{services[0].f3}</span>
       </p>
 
       <Link

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -73,7 +73,7 @@ const Card = props => {
       </div>
       <p css={tw`mb-4`}>
         <span css={tw`font-semibold`}>Type of care:</span>{' '}
-        <span>{services[0].f3}</span>
+        <span>{services[1].f3}</span>
       </p>
 
       <Link

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -67,10 +67,10 @@ class Home extends Component {
               <h3 css={tw`text-4xl font-light text-gray-700`}>
                 What to expect
               </h3>
-              <h4 css={tw`text-xl font-light text-gray-700`}>
+              <span css={tw`block text-xl font-light text-gray-700`}>
                 Help is available, treatment works, and people recover every
                 day.
-              </h4>
+              </span>
             </div>
             <div css={tw`flex flex-wrap -mx-2`}>
               {content.map(card => (

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -12,7 +12,7 @@ const content = [
     slug: 'understanding-addiction',
     heading: 'Understanding addiction',
     body:
-      'Addiction is a chronic disease that changes the brain and alters decision-making. Treatment works, help is available, and people recover from addiction every day.'
+      'Addiction is a chronic disease that changes the brain and alters decision-making.'
   },
   {
     slug: 'treatment-options',
@@ -67,6 +67,10 @@ class Home extends Component {
               <h3 css={tw`text-4xl font-light text-gray-700`}>
                 What to expect
               </h3>
+              <h4 css={tw`text-xl font-light text-gray-700`}>
+                Treatment works, help is available, and people recover every
+                day.
+              </h4>
             </div>
             <div css={tw`flex flex-wrap -mx-2`}>
               {content.map(card => (

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -68,7 +68,7 @@ class Home extends Component {
                 What to expect
               </h3>
               <h4 css={tw`text-xl font-light text-gray-700`}>
-                Treatment works, help is available, and people recover every
+                Help is available, treatment works, and people recover every
                 day.
               </h4>
             </div>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -61,7 +61,10 @@ class Nav extends Component {
               <Link to="/" css={tw`block mt-4 lg:inline-block lg:mt-0 mr-6`}>
                 Search for treatment
               </Link>
-              <Link to="/" css={tw`block mt-4 lg:inline-block lg:mt-0`}>
+              <Link
+                to="/content/what-to-expect"
+                css={tw`block mt-4 lg:inline-block lg:mt-0`}
+              >
                 What to expect
               </Link>
             </div>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -16,7 +16,7 @@ const SideBar = styled.div`
 `;
 
 const Content = styled.div`
-  ${tw`w-full lg:w-2/3 px-6 mb-6`}
+  ${tw`w-full lg:w-2/3 px-6 mb-10`}
 
   div:last-child {
     ${tw`border-b-0 mb-0 pb-0`}
@@ -89,24 +89,25 @@ class Page extends Component {
                     </Link>
                     {id === match.params.pageId && (
                       <ul css={tw`my-2`}>
-                        {subTopics.map(({ name, body }) => (
-                          <li key={convertToSlug(name)} css={tw`mb-3`}>
-                            <HashLink
-                              smooth
-                              to={`#${convertToSlug(name)}`}
-                              css={tw`text-gray-700 border-l-4 border-gray-200 px-2 py-1`}
-                              style={
-                                location.hash === `#${convertToSlug(name)}`
-                                  ? {
-                                      borderColor: '#3182ce'
-                                    }
-                                  : {}
-                              }
-                            >
-                              {name}
-                            </HashLink>
-                          </li>
-                        ))}
+                        {subTopics &&
+                          subTopics.map(({ name, body }) => (
+                            <li key={convertToSlug(name)} css={tw`mb-3`}>
+                              <HashLink
+                                smooth
+                                to={`#${convertToSlug(name)}`}
+                                css={tw`text-gray-700 border-l-4 border-gray-200 px-2 py-1`}
+                                style={
+                                  location.hash === `#${convertToSlug(name)}`
+                                    ? {
+                                        borderColor: '#3182ce'
+                                      }
+                                    : {}
+                                }
+                              >
+                                {name}
+                              </HashLink>
+                            </li>
+                          ))}
                       </ul>
                     )}
                   </li>
@@ -115,16 +116,20 @@ class Page extends Component {
             </div>
           </SideBar>
           <Content>
-            <h1 css={tw`text-5xl`}>{topic.name}</h1>
-            <p css={tw`text-xl font-light mb-8 max-w-xl`}>
-              {topic.description}
-            </p>
-            {topic.subTopics.map(({ name, body }) => (
-              <Topic key={convertToSlug(name)}>
-                <h2 id={convertToSlug(name)}>{name}</h2>
-                {body}
-              </Topic>
-            ))}
+            {topic.name && <h1 css={tw`text-5xl`}>{topic.name}</h1>}
+            {topic.description && (
+              <p css={tw`text-xl font-light mb-8 max-w-xl`}>
+                {topic.description}
+              </p>
+            )}
+            {topic.body && <Topic>{topic.body}</Topic>}
+            {topic.subTopics &&
+              topic.subTopics.map(({ name, body }) => (
+                <Topic key={convertToSlug(name)}>
+                  <h2 id={convertToSlug(name)}>{name}</h2>
+                  {body}
+                </Topic>
+              ))}
           </Content>
         </StyledPage>
       </div>

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -7,7 +7,7 @@ export default () => [
     name: 'What to expect',
     id: 'what-to-expect',
     description:
-      'Treatment works, help is available, and people recover every day.',
+      'Help is available, treatment works, and people recover every day.',
     subTopics: [
       {
         name: 'What to expect',

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -8,26 +8,21 @@ export default () => [
     id: 'what-to-expect',
     description:
       'Help is available, treatment works, and people recover every day.',
-    subTopics: [
-      {
-        name: 'What to expect',
-        body: (
-          <>
-            <p>
-              Beginning recovery can be overwhelming and intimidating. While
-              everyone's path to recovery is unique, there are certain things
-              you can expect and be ready for when you start.
-            </p>
-            <p>
-              There is help. From understanding more about addiction and
-              treatment options, to being ready to navigate insurance and
-              payment, this information can help you feel more confident as you
-              take the next step to finding treatment.
-            </p>
-          </>
-        )
-      }
-    ]
+    body: (
+      <>
+        <p>
+          Beginning recovery can be overwhelming and intimidating. While
+          everyone's path to recovery is unique, there are certain things you
+          can expect and be ready for when you start.
+        </p>
+        <p>
+          There is help. From understanding more about addiction and treatment
+          options, to being ready to navigate insurance and payment, this
+          information can help you feel more confident as you take the next step
+          to finding treatment.
+        </p>
+      </>
+    )
   },
   {
     name: 'Understanding addiction',

--- a/src/utils/topics.js
+++ b/src/utils/topics.js
@@ -7,13 +7,34 @@ export default () => [
   {
     name: 'What to expect',
     id: 'what-to-expect',
-    description: 'blurb'
+    description:
+      'Treatment works, help is available, and people recover every day.',
+    subTopics: [
+      {
+        name: 'What to expect',
+        body: (
+          <>
+            <p>
+              Beginning recovery can be overwhelming and intimidating. While
+              everyone's path to recovery is unique, there are certain things
+              you can expect and be ready for when you start.
+            </p>
+            <p>
+              There is help. From understanding more about addiction and
+              treatment options, to being ready to navigate insurance and
+              payment, this information can help you feel more confident as you
+              take the next step to finding treatment.
+            </p>
+          </>
+        )
+      }
+    ]
   },
   {
     name: 'Understanding addiction',
     id: 'understanding-addiction',
     description:
-      'Addiction is a chronic disease that changes the brain and alters decision-making. Treatment works, help is available, and people recover from addiction every day.',
+      'Addiction is a chronic disease that changes the brain and alters decision-making.',
     subTopics: [
       {
         name: 'Addiction can affect anyone',


### PR DESCRIPTION
- Added 'what to expect' content from Amanda 
- Updated home page ledes
- Added subtitle under "what to expect" on homepage (I asked Nick to provide more feedback on this as part of his work on that section)

Still to do, which might be better for @hursey013 to do: 
- Link to the 'what to expect' content section in top nav
- Remove subtopic from 'what to expect' section (Note: @hursey013 - Can we make it so that we don't have subtopics for this section? Ideally there are no jump downs within this section, but we could always get Amanda to write something else. For now, I have "what to expect" again as a placeholder.)
