### PR TITLE
Setting CrazyEgg snapshot tracking names for a handful of components

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
     -->
     <title>Treatment Finder</title>
     <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_API_KEY%&libraries=places"></script>
+    <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0083/6179.js" async="async"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/middleware/analytics.js
+++ b/src/middleware/analytics.js
@@ -20,13 +20,13 @@ const trackPage = page => {
 
 let currentPage = '';
 
-export const googleAnalytics = store => next => action => {
+export const analytics = store => next => action => {
   if (action.type === '@@router/LOCATION_CHANGE') {
     const nextPage = `${action.payload.location.pathname}${action.payload.location.search}`;
-
     if (currentPage !== nextPage) {
       currentPage = nextPage;
       trackPage(nextPage);
+      window.CE_SNAPSHOT_NAME = 'findtreatmentbeta: ' + nextPage;
     }
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,7 @@ import { createBrowserHistory } from 'history';
 import { applyMiddleware, compose, createStore } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import thunk from 'redux-thunk';
-import logger from 'redux-logger';
+import { createLogger } from 'redux-logger';
 import { googleAnalytics } from './middleware/reactGA';
 import createRootReducer from './reducers';
 
@@ -13,6 +13,9 @@ export const history = createBrowserHistory({
 const middleware = [routerMiddleware(history), thunk];
 
 if (process.env.NODE_ENV !== 'production') {
+  const logger = createLogger({
+    collapsed: true
+  });
   middleware.push(logger);
 } else {
   middleware.push(googleAnalytics);

--- a/src/store.js
+++ b/src/store.js
@@ -3,7 +3,7 @@ import { applyMiddleware, compose, createStore } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
-import { googleAnalytics } from './middleware/reactGA';
+import { analytics } from './middleware/analytics';
 import createRootReducer from './reducers';
 
 export const history = createBrowserHistory({
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV !== 'production') {
   });
   middleware.push(logger);
 } else {
-  middleware.push(googleAnalytics);
+  middleware.push(analytics);
 }
 
 export default function configureStore(preloadedState) {


### PR DESCRIPTION
For #60, this allows snapshot tracking for:

Landing page
Details page
Results List page
Each individual content page

Needs setup on CE as well,