### PR TITLE
Add reported facility to store

### DIFF
--- a/src/actions/facilities.js
+++ b/src/actions/facilities.js
@@ -5,6 +5,7 @@ import ReactGA from 'react-ga';
 export const RECEIVE_FACILITIES_BEGIN = 'RECEIVE_FACILITIES_BEGIN';
 export const RECEIVE_FACILITIES_SUCCESS = 'RECEIVE_FACILITIES_SUCCESS';
 export const RECEIVE_FACILITIES_FAILURE = 'RECEIVE_FACILITIES_FAILURE';
+export const REPORT_FACILITY = 'REPORT_FACILITY';
 export const DESTROY_FACILITIES = 'DESTROY_FACILITIES';
 
 const trackSearchResults = (params, results) => {
@@ -32,6 +33,13 @@ export const receiveFacilitiesSucess = data => {
 export const receiveFacilitiesFailure = error => {
   return {
     type: RECEIVE_FACILITIES_FAILURE
+  };
+};
+
+export const reportFacility = frid => {
+  return {
+    type: REPORT_FACILITY,
+    frid
   };
 };
 

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect, Link } from 'react-router-dom';
 import 'styled-components/macro';
@@ -10,11 +9,13 @@ import {
   faExternalLinkAlt,
   faFlag
 } from '@fortawesome/free-solid-svg-icons';
+import { reportFacility } from '../actions/facilities';
+
 import MapContainer from './Map/MapContainer';
 import Button from './Form/Button';
-import ReactGA, { OutboundLink } from 'react-ga';
+import { OutboundLink } from 'react-ga';
 
-class Details extends Component {
+export class Details extends Component {
   renderService(service) {
     return (
       <div css={tw`mb-4 pb-4 border-b`} key={service.f2}>
@@ -30,12 +31,9 @@ class Details extends Component {
     );
   }
 
-  flagData = frid => {
-    ReactGA.event({
-      category: `Listing Data Report`,
-      action: `Data issue reported for frid`,
-      label: frid.frid
-    });
+  reportFacility = () => {
+    const { facility } = this.props;
+    this.props.reportFacility(facility.frid);
   };
 
   render() {
@@ -44,7 +42,6 @@ class Details extends Component {
     }
 
     const {
-      frid,
       name1,
       name2,
       street1,
@@ -136,10 +133,23 @@ class Details extends Component {
                 </OutboundLink>
               </div>
             </div>
-            <Button secondary onClick={() => this.flagData({ frid })}>
-              <FontAwesomeIcon icon={faFlag} css={tw`text-orange-600 mr-2`} />
-              Report a problem with this listing
-            </Button>
+            {!this.props.isReported ? (
+              <Button
+                className="report-facility"
+                secondary
+                onClick={this.reportFacility}
+              >
+                <FontAwesomeIcon icon={faFlag} css={tw`text-orange-600 mr-2`} />
+                Report a problem with this listing
+              </Button>
+            ) : (
+              <div
+                role="alert"
+                css={tw`w-full text-center rounded bg-green-100 border border-green-500 text-green-700 px-4 py-3`}
+              >
+                <strong>Thank you!</strong> Your feedback has been recorded.
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -147,30 +157,25 @@ class Details extends Component {
   }
 }
 
-Details.propTypes = {
-  frid: PropTypes.string.isRequired,
-  name1: PropTypes.string.isRequired,
-  name2: PropTypes.string,
-  miles: PropTypes.number.isRequired,
-  street1: PropTypes.string.isRequired,
-  street2: PropTypes.string,
-  city: PropTypes.string.isRequired,
-  state: PropTypes.string.isRequired,
-  zip: PropTypes.string.isRequired,
-  services: PropTypes.array.isRequired,
-  phone: PropTypes.string.isRequired,
-  website: PropTypes.string
-};
+const mapDispatchToProps = dispatch => ({
+  reportFacility(frid) {
+    dispatch(reportFacility(frid));
+  }
+});
 
 const mapStateToProps = ({ facilities }, ownProps) => {
-  const { data } = facilities;
+  const { data, reported } = facilities;
   const { rows } = data;
   const facility =
     rows && rows.find(({ frid }) => frid === ownProps.location.state.id);
 
   return {
-    facility
+    facility,
+    isReported: facility && reported.includes(facility.frid)
   };
 };
 
-export default connect(mapStateToProps)(Details);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Details);

--- a/src/middleware/analytics.js
+++ b/src/middleware/analytics.js
@@ -36,5 +36,13 @@ export const analytics = store => next => action => {
     }
   }
 
+  if (action.type === 'REPORT_FACILITY') {
+    ReactGA.event({
+      category: `Listing Data Report`,
+      action: `Data issue reported for frid`,
+      label: action.frid
+    });
+  }
+
   return next(action);
 };

--- a/src/reducers/facilities.js
+++ b/src/reducers/facilities.js
@@ -2,11 +2,13 @@ import {
   RECEIVE_FACILITIES_BEGIN,
   RECEIVE_FACILITIES_SUCCESS,
   RECEIVE_FACILITIES_FAILURE,
+  REPORT_FACILITY,
   DESTROY_FACILITIES
 } from '../actions/facilities';
 
 const initialState = {
   data: {},
+  reported: [],
   loading: false
 };
 
@@ -28,6 +30,13 @@ export default function facilities(state = initialState, action) {
         ...state,
         loading: false,
         data: {}
+      };
+    case REPORT_FACILITY:
+      return {
+        ...state,
+        reported: state.reported
+          .filter(frid => frid !== action.frid)
+          .concat(action.frid)
       };
     case DESTROY_FACILITIES:
       return initialState;


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/62

This adds some visual feedback for when a facility is reported:
<img width="482" alt="Screen Shot 2019-07-18 at 3 56 31 PM" src="https://user-images.githubusercontent.com/1178494/61487766-ad482e00-a974-11e9-9087-11b53b1100d6.png">
...and limits reporting to once per session. The caveat being since it's not currently stored anywhere, reloading the app would allow someone to report the facility again. Future PR could make use of localStorage to make remembering what facilities have been reported more sticky.

This needs some tests, but will follow up with them in a future PR as well.