### PR TITLE
Display current number range of results

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -44,6 +44,8 @@ class Pagination extends Component {
         page: data.selected + 1
       })
     );
+
+    window.scrollTo(0, 0);
   };
 
   render() {

--- a/src/components/ResultsList.js
+++ b/src/components/ResultsList.js
@@ -2,6 +2,9 @@ import React, { Component } from 'react';
 import 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { Link } from 'react-router-dom';
+
+import { DEFAULT_PAGE_SIZE } from '../utils/constants';
+
 import Loading from './Loading';
 import NoResults from './NoResults';
 import Card from './Card';
@@ -11,6 +14,7 @@ export class ResultsList extends Component {
   render() {
     const { loading, rows, page, totalPages, recordCount } = this.props;
     const hasResults = rows && rows.length > 0;
+    const offset = (page - 1) * DEFAULT_PAGE_SIZE;
 
     if (loading) {
       return <Loading />;
@@ -30,8 +34,7 @@ export class ResultsList extends Component {
             </span>
           </h1>
           <span css={tw`block text-gray-500`}>
-            Showing page {page} of {totalPages}{' '}
-            <span css={tw`italic`}>({recordCount} results)</span>
+            Showing {offset + 1}-{offset + rows.length} of {recordCount}
           </span>
         </div>
         <div

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { DEFAULT_PAGE_SIZE } from './constants';
 
 export default axios.create({
   baseURL:
@@ -11,7 +12,7 @@ export default axios.create({
 const initialValues = {
   sType: 'BOTH',
   sCodes: '',
-  pageSize: 10,
+  pageSize: DEFAULT_PAGE_SIZE,
   page: 1,
   sort: 0
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,2 +1,3 @@
 export const ADVANCED_FILTERS = ['age', 'language', 'VET', 'GL', 'mat'];
 export const DEFAULT_DISTANCE = 16093.4;
+export const DEFAULT_PAGE_SIZE = 10;


### PR DESCRIPTION
Right now on the results page it shows something like `Showing page 2 of 2 (14 results)` which is not a common way to describe the current result set.

This updates the page to display the current range instead, such as `Showing 1-10 of 19`.