### PR TITLE
Add print styles

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,7 +17,7 @@ import Footer from './Footer';
 
 const GlobalStyle = createGlobalStyle`
   body {
-    ${tw`font-sans text-gray-900 leading-normal`}
+    ${tw`font-sans text-gray-900 leading-normal print:text-black`}
   }
 `;
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -100,7 +100,10 @@ const Card = props => {
         zip={zip}
       />
       <CardDetails phone={phone} website={website} services={services} />
-      <Link to={{ pathname: '/details', state: { frid } }}>
+      <Link
+        to={{ pathname: '/details', state: { frid } }}
+        css={tw`print:hidden`}
+      >
         <Button primary>View provider details</Button>
       </Link>
     </StyledCard>

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -58,7 +58,7 @@ export class Details extends Component {
       <div className="container">
         <div css={tw`flex flex-wrap -mx-6`}>
           <div css={tw`w-full md:w-3/5 px-6 mb-6`}>
-            <Button link onClick={this.returnToResults}>
+            <Button link onClick={this.returnToResults} css={tw`print:hidden`}>
               ❮ Return to results
             </Button>
             <h1 css={tw`font-bold mb-6`}>
@@ -67,7 +67,15 @@ export class Details extends Component {
             </h1>
             <div css={tw`border-l-4 border-blue-500 py-2 px-4 mb-6`}>
               <h2 css={tw`mb-2 font-semibold`}>Next step:</h2>
-              <div css={tw`lg:flex items-start`}>
+              <ul css={tw`hidden print:block`}>
+                <li>
+                  <span css={tw`font-bold`}>Phone:</span> {phone}
+                </li>
+                <li>
+                  <span css={tw`font-bold`}>Website:</span> {website}
+                </li>
+              </ul>
+              <div css={tw`lg:flex items-start print:hidden`}>
                 <OutboundLink to={`tel:${phone}`} eventLabel="Facility Phone #">
                   <Button
                     primary
@@ -102,7 +110,7 @@ export class Details extends Component {
               </div>
               <Link
                 to="/content/treatment-options#calling-a-facility"
-                css={tw`mb-2 text-sm`}
+                css={tw`mb-2 text-sm print:hidden`}
               >
                 What to expect when you call
               </Link>
@@ -139,6 +147,7 @@ export class Details extends Component {
             {!this.props.isReported ? (
               <Button
                 className="report-facility"
+                css={tw`print:hidden`}
                 secondary
                 onClick={this.reportFacility}
               >

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -7,7 +7,7 @@ import { ReactComponent as LogoSAMHSA } from '../images/logo-samhsa.svg';
 import { ReactComponent as LogoHHS } from '../images/logo-hhs.svg';
 
 const StyledFooter = styled.div`
-  ${tw`bg-gray-800 text-gray-200 text-xs`}
+  ${tw`bg-gray-800 text-gray-200 text-xs print:hidden`}
 
   a {
     ${tw`text-white hover:text-white`}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -9,7 +9,7 @@ import HeaderNav from './HeaderNav';
 
 const Header = () => {
   return (
-    <>
+    <div css={tw`print:hidden`}>
       <HeaderBeta />
       <div css={tw`bg-gray-200`}>
         <div css={tw`lg:relative lg:mx-auto max-w-full lg:max-w-5xl`}>
@@ -18,7 +18,7 @@ const Header = () => {
         </div>
       </div>
       <HeaderNav />
-    </>
+    </div>
   );
 };
 

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -46,7 +46,7 @@ export class Results extends Component {
     return (
       <div className="container">
         <div css={tw`flex flex-wrap -mx-6`}>
-          <div css={tw`w-full lg:w-2/5 px-6 mb-6`}>
+          <div css={tw`w-full lg:w-2/5 px-6 mb-6 print:hidden`}>
             <FormFilters
               onSubmit={this.submit}
               toggleFilters={this.toggleFilters}

--- a/src/components/ResultsList.js
+++ b/src/components/ResultsList.js
@@ -38,7 +38,7 @@ export class ResultsList extends Component {
           </span>
         </div>
         <div
-          css={tw`mb-6 rounded bg-blue-100 border border-blue-500 text-blue-700 px-4 py-3`}
+          css={tw`mb-6 rounded bg-blue-100 print:bg-transparent border border-blue-500 print:border-black text-blue-700 print:text-black px-4 py-3`}
         >
           <p css={tw`font-bold`}>Before you visit</p>
           <p css={tw`text-sm mb-4`}>

--- a/src/css/tailwind.src.css
+++ b/src/css/tailwind.src.css
@@ -39,6 +39,12 @@ a:hover {
   color: theme('colors.blue.800');
 }
 
+@screen print {
+  a {
+    color: theme('colors.black');
+  }
+}
+
 address,
 ol,
 p,

--- a/src/tailwind.js
+++ b/src/tailwind.js
@@ -22,6 +22,9 @@ module.exports = {
           '800': '#0F4756',
           '900': '#033340'
         }
+      },
+      screens: {
+        print: { raw: 'print' }
       }
     }
   },


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/31

Optimized the results list and facility page for printing. Upon printing the following areas will be hidden:

- Header/navigation
- Filter box
- Footer

I also selectively hid some buttons and links that were not relevant for a printing and changed colored text/links to black. There are likely some more optimizations to make, but this addresses the basics and can be adapted once a more final design is in place.