### PR TITLE
Add error page for when endpoint is down

### DIFF
--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import tw from 'tailwind.macro';
+import 'styled-components/macro';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPhone } from '@fortawesome/free-solid-svg-icons';
+import { OutboundLink } from 'react-ga';
+
+import { HELPLINE_LINK, HELPLINE_TEXT } from '../utils/constants';
+
+import { Button } from './Input';
+
+const Error = () => (
+  <div css={tw`mx-auto p-6 mb-6 text-center`}>
+    <h2 css={tw`text-3xl font-bold mb-10`}>Something's wrong on our side.</h2>
+    <div css={tw`max-w-xl mx-auto`}>
+      <p css={tw`text-xl mb-6`}>
+        We're having technical issues right now. The problem should be fixed
+        soon, and in the meantime SAMHSA's national helpline is available 24/7
+        and can assist you with treatment referrals and information.
+      </p>
+      <OutboundLink
+        eventLabel="Helpline link from 404"
+        to={`tel:${HELPLINE_LINK}`}
+      >
+        <Button primary>
+          <FontAwesomeIcon icon={faPhone} css={tw`mr-2`} className="fa-lg" />
+          {HELPLINE_TEXT}
+        </Button>
+      </OutboundLink>
+    </div>
+  </div>
+);
+
+export default Error;

--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -19,7 +19,7 @@ const Error = () => (
         and can assist you with treatment referrals and information.
       </p>
       <OutboundLink
-        eventLabel="Helpline link from 404"
+        eventLabel="Helpline link from error page"
         to={`tel:${HELPLINE_LINK}`}
       >
         <Button primary>

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { handleReceiveFacilities } from '../actions/facilities';
 
 import ScreenContext from './ScreenContext';
+import Error from './Error';
 import ResultsList from './ResultsList';
 import FormFilters from './Form/FormFilters';
 import MapContainer from './Map/MapContainer';
@@ -39,10 +40,14 @@ export class Results extends Component {
   };
 
   render() {
-    const { loading, data } = this.props;
+    const { loading, error, data } = this.props;
     const { rows, page, totalPages, recordCount } = data;
     const hasResults = !!(rows && rows.length > 0);
     const isDesktop = this.context;
+
+    if (error) {
+      return <Error />;
+    }
 
     return (
       <div className="container">
@@ -88,14 +93,16 @@ Results.contextType = ScreenContext;
 Results.propTypes = {
   dispatch: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
+  error: PropTypes.bool.isRequired,
   data: PropTypes.object.isRequired
 };
 
 const mapStateToProps = ({ facilities }) => {
-  const { loading, data } = facilities;
+  const { loading, error, data } = facilities;
 
   return {
     loading,
+    error,
     data
   };
 };

--- a/src/reducers/facilities.js
+++ b/src/reducers/facilities.js
@@ -10,7 +10,8 @@ import { servicesToObject } from '../utils/misc';
 const initialState = {
   data: {},
   reported: [],
-  loading: false
+  loading: false,
+  error: false
 };
 
 export default function facilities(state = initialState, action) {
@@ -18,25 +19,29 @@ export default function facilities(state = initialState, action) {
     case RECEIVE_FACILITIES_BEGIN:
       return {
         ...state,
-        loading: true
+        data: {},
+        loading: true,
+        error: false
       };
     case RECEIVE_FACILITIES_SUCCESS:
       return {
         ...state,
-        loading: false,
         data: {
           ...action.payload.data,
           rows: action.payload.data.rows.map(facility => ({
             ...facility,
             services: servicesToObject(facility.services)
           }))
-        }
+        },
+        loading: false,
+        error: false
       };
     case RECEIVE_FACILITIES_FAILURE:
       return {
         ...state,
+        data: {},
         loading: false,
-        data: {}
+        error: true
       };
     case REPORT_FACILITY:
       return {
@@ -46,7 +51,12 @@ export default function facilities(state = initialState, action) {
           .concat(action.frid)
       };
     case DESTROY_FACILITIES:
-      return initialState;
+      return {
+        ...state,
+        data: {},
+        loading: false,
+        error: false
+      };
     default:
       return state;
   }


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/43

Adds error page in case vendor endpoint is down. Including screenshot of page since there is no easy way to reproduce on preview site:

<img width="635" alt="Screen Shot 2019-08-01 at 1 39 00 PM" src="https://user-images.githubusercontent.com/1178494/62314794-dcc16500-b461-11e9-8dea-5028038d9cf4.png">
