### PR TITLE
Improve contrast by darkening text and backgrounds

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -10,7 +10,7 @@ import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
 import { Button } from './Input';
 
 const StyledHeading = tw.div`flex justify-between`;
-const StyledAddress = tw.address`text-gray-600 not-italic`;
+const StyledAddress = tw.address`text-gray-700 not-italic`;
 const StyledCard = tw.li`shadow border rounded p-6 mb-6`;
 
 const renderService = service => {
@@ -35,7 +35,7 @@ const CardHeading = ({ frid, name1, name2, miles }) => (
       </h2>
     </Link>
     {miles && (
-      <span className="card-miles" css={tw`text-gray-500`}>
+      <span className="card-miles" css={tw`text-gray-800`}>
         {miles} miles
       </span>
     )}
@@ -44,7 +44,7 @@ const CardHeading = ({ frid, name1, name2, miles }) => (
 
 const CardAddress = ({ street1, street2, city, state, zip }) => (
   <StyledAddress>
-    <FontAwesomeIcon icon={faMapMarkerAlt} css={tw`text-gray-400 mr-1`} />
+    <FontAwesomeIcon icon={faMapMarkerAlt} css={tw`text-gray-700 mr-1`} />
     {street1}, {street2 && street2 + ', '}
     {city}, {state} {zip}
   </StyledAddress>

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -135,7 +135,7 @@ export class Details extends Component {
                   singleMarker={true}
                 />
               </div>
-              <div css={tw`text-gray-600`}>
+              <div css={tw`text-gray-700`}>
                 {street1}, {street2 && street2 + ','}
                 <br />
                 {city}, {state} {zip}

--- a/src/components/Input/Button.js
+++ b/src/components/Input/Button.js
@@ -10,14 +10,14 @@ const Button = styled.button`
 
   ${props => props.secondary && tw`w-full bg-gray-100 hover:bg-gray-200 border`}
 
-  ${props => props.outline && tw`text-blue-700 border border-blue-500`}
+  ${props => props.outline && tw`text-blue-700 border border-blue-700`}
 
   ${props =>
     props.base &&
     tw`hover:text-gray-900 text-gray-900 bg-gray-300 hover:bg-gray-400`}
 
   ${props =>
-    props.disable && tw`hover:bg-blue-500 cursor-not-allowed opacity-50`}
+    props.disable && tw`hover:bg-blue-700 cursor-not-allowed opacity-50`}
 
   ${props =>
     props.link && tw`text-blue-700 hover:text-blue-800 font-normal p-0`}

--- a/src/components/Input/Button.js
+++ b/src/components/Input/Button.js
@@ -6,11 +6,11 @@ const Button = styled.button`
 
   ${props =>
     props.primary &&
-    tw`bg-blue-500 hover:bg-blue-700 border border-blue-500 text-white`}
+    tw`bg-blue-700 hover:bg-blue-900 border border-blue-700 text-white`}
 
   ${props => props.secondary && tw`w-full bg-gray-100 hover:bg-gray-200 border`}
 
-  ${props => props.outline && tw`text-blue-600 border border-blue-500`}
+  ${props => props.outline && tw`text-blue-700 border border-blue-500`}
 
   ${props =>
     props.base &&

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -23,11 +23,11 @@ const StyledPagination = styled.div`
   }
 
   .disabled a {
-    ${tw`text-gray-500 bg-transparent hover:bg-transparent cursor-not-allowed`}
+    ${tw`text-gray-700 bg-transparent hover:bg-transparent cursor-not-allowed`}
   }
 
   .selected a {
-    ${tw`text-white bg-blue-500 hover:bg-blue-500`}
+    ${tw`text-white bg-blue-700 hover:bg-blue-500`}
   }
 `;
 
@@ -60,6 +60,7 @@ class Pagination extends Component {
           pageRangeDisplayed={3}
           onPageChange={this.handlePageClick}
           forcePage={page - 1}
+          css={tw`text-purple-800`}
         />
       </StyledPagination>
     );

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -60,7 +60,6 @@ class Pagination extends Component {
           pageRangeDisplayed={3}
           onPageChange={this.handlePageClick}
           forcePage={page - 1}
-          css={tw`text-purple-800`}
         />
       </StyledPagination>
     );

--- a/src/components/ResultsList.js
+++ b/src/components/ResultsList.js
@@ -36,11 +36,11 @@ export class ResultsList extends Component {
         <div css={tw`lg:flex lg:justify-between lg:items-baseline mb-6`}>
           <h1 css={tw`mb-2 lg:mb-0`}>
             Results{' '}
-            <span css={tw`text-lg text-gray-600 font-light`}>
+            <span css={tw`text-lg text-gray-700 font-light`}>
               Treatment providers near you
             </span>
           </h1>
-          <span css={tw`block text-gray-500`}>
+          <span css={tw`block text-gray-700`}>
             Showing {offset + 1}-{offset + rows.length} of {recordCount}
           </span>
         </div>


### PR DESCRIPTION
Herein, for #187, we darken the grey used as `text-color` and blue used as button backgrounds to reach a desired contrast ratio of 4.5:1 throughout the site. 