### PR TITLE
Add title attributes when rendering google maps iframes

### DIFF
--- a/src/components/Map/MapContainer.js
+++ b/src/components/Map/MapContainer.js
@@ -52,17 +52,23 @@ export class MapContainer extends Component {
     }
   };
 
-  adjustMap = (_, map) => {
-    const { rows } = this.props;
-    const bounds = new window.google.maps.LatLngBounds();
+  onReady = (_, map) => {
+    const { rows, singleMarker } = this.props;
 
-    rows.forEach(location => {
-      bounds.extend(
-        new window.google.maps.LatLng(location.latitude, location.longitude)
-      );
+    if (!singleMarker) {
+      const bounds = new window.google.maps.LatLngBounds();
+      rows.forEach(location => {
+        bounds.extend(
+          new window.google.maps.LatLng(location.latitude, location.longitude)
+        );
+      });
+      map.fitBounds(bounds);
+    }
+
+    // Add title to google map iframe
+    window.google.maps.event.addListenerOnce(map, 'idle', () => {
+      document.getElementsByTagName('iframe')[0].title = 'Google Maps';
     });
-
-    map.fitBounds(bounds);
   };
 
   getInitialCenter() {
@@ -95,7 +101,7 @@ export class MapContainer extends Component {
         fullscreenControl={false}
         mapTypeControl={false}
         streetViewControl={false}
-        onReady={!singleMarker && this.adjustMap}
+        onReady={this.onReady}
         onClick={this.onMapClicked}
       >
         {rows.map(location => {

--- a/src/components/Map/MapContainer.test.js
+++ b/src/components/Map/MapContainer.test.js
@@ -35,7 +35,8 @@ const locations = [
   }
 ];
 const defaultProps = {
-  rows: locations
+  rows: locations,
+  singleMarker: false
 };
 
 describe('MapContainer component', () => {
@@ -91,7 +92,7 @@ describe('MapContainer component', () => {
         expect(component.find('DOMInfoWindow').prop('visible')).toBe(false);
       });
 
-      it('adjusts the bounds when dragged', () => {
+      it('adjusts the bounds once map is ready', () => {
         const map = component.find('Map');
         const googleMap = new window.google.maps.Map();
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -13,6 +13,7 @@ window.google = {
         this.fitBoundsCalls = fitBounds.mock.calls.length;
       }
     },
+    event: { addListenerOnce: jest.fn() },
     LatLng: class {
       constructor(latitude, longitude) {
         this.lat = latitude;


### PR DESCRIPTION
For #186, we add a `title` to each iframe when rendered and ready for interaction on the page.