### PR TITLE
Single focusable element for facility details links

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -111,7 +111,7 @@ const Card = props => {
         as={Link}
         to={{ pathname: '/details', state: { frid } }}
         css={tw`print:hidden`}
-        outline="true"
+        primary="true"
       >
         View provider details
       </Button>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -107,12 +107,14 @@ const Card = props => {
         zip={zip}
       />
       <CardDetails phone={phone} website={website} services={services} />
-      <Link
+      <Button
+        as={Link}
         to={{ pathname: '/details', state: { frid } }}
         css={tw`print:hidden`}
+        outline="true"
       >
-        <Button primary>View provider details</Button>
-      </Link>
+        View provider details
+      </Button>
     </StyledCard>
   );
 };

--- a/src/components/Input/Button.js
+++ b/src/components/Input/Button.js
@@ -6,7 +6,7 @@ const Button = styled.button`
 
   ${props =>
     props.primary &&
-    tw`bg-blue-700 hover:bg-blue-900 border border-blue-700 text-white`}
+    tw`bg-blue-700 hover:bg-blue-900 border border-blue-700 text-white hover:text-white hover:border-blue-900`}
 
   ${props => props.secondary && tw`w-full bg-gray-100 hover:bg-gray-200 border`}
 

--- a/src/components/Map/InfoWindowText.js
+++ b/src/components/Map/InfoWindowText.js
@@ -26,7 +26,7 @@ export const InfoWindowText = props => {
         <Button
           as={Link}
           css={tw`p-1 w-full`}
-          outline="true"
+          primary="true"
           to={{
             pathname: '/details',
             state: { frid: selectedPlace.details.frid }

--- a/src/components/Map/InfoWindowText.js
+++ b/src/components/Map/InfoWindowText.js
@@ -23,17 +23,17 @@ export const InfoWindowText = props => {
         </OutboundLink>
       </p>
       {!singleMarker && (
-        <Link
+        <Button
+          as={Link}
+          css={tw`p-1 w-full`}
+          outline="true"
           to={{
             pathname: '/details',
             state: { frid: selectedPlace.details.frid }
           }}
-          css={tw`block`}
         >
-          <Button css={tw`p-1 w-full`} primary>
-            View provider details
-          </Button>
-        </Link>
+          View provider details
+        </Button>
       )}
     </>
   );


### PR DESCRIPTION
For #189, we render the links to facility details from the Results page as a single anchor element. 

This includes a small visual change as we're falling back on the existing styling for ` <Button 
as={Link} outline="true" ...`

![Screen Shot 2019-08-06 at 10 58 39 AM](https://user-images.githubusercontent.com/3485564/62652224-dbdc7780-b928-11e9-88fd-18df4994b732.png)