### PR TITLE
Route to facility page based on FRID

### DIFF
--- a/src/actions/facility.js
+++ b/src/actions/facility.js
@@ -1,0 +1,68 @@
+import qs from 'qs';
+
+import API from '../utils/api';
+import { DEFAULT_STYPE } from '../utils/constants';
+
+export const RECEIVE_FACILITY_BEGIN = 'RECEIVE_FACILITY_BEGIN';
+export const RECEIVE_FACILITY_SUCCESS = 'RECEIVE_FACILITY_SUCCESS';
+export const RECEIVE_FACILITY_FAILURE = 'RECEIVE_FACILITY_FAILURE';
+export const DESTROY_FACILITY = 'DESTROY_FACILITY';
+
+export const receiveFacilityBegin = () => {
+  return {
+    type: RECEIVE_FACILITY_BEGIN
+  };
+};
+
+export const receiveFacilitySucess = (data, frid) => {
+  return {
+    type: RECEIVE_FACILITY_SUCCESS,
+    payload: { data },
+    frid
+  };
+};
+
+export const receiveFacilityFailure = error => {
+  return {
+    type: RECEIVE_FACILITY_FAILURE
+  };
+};
+
+export const destroyFacility = () => {
+  return {
+    type: DESTROY_FACILITY
+  };
+};
+
+export function handleReceiveFacility(frid, query) {
+  return dispatch => {
+    dispatch(receiveFacilityBegin());
+
+    const params = {
+      sType: DEFAULT_STYPE,
+      pageSize: 100, // Return up to 100 results in initial fetch
+      sAddr: query.sAddr,
+      limitType: 2, // Limit by distance
+      limitValue: 0 // Match the exact lat/lng only
+    };
+
+    const options = {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      data: qs.stringify(params),
+      url: '/listing'
+    };
+
+    return API(options)
+      .then(response => {
+        if (response.data) {
+          dispatch(receiveFacilitySucess(response.data, frid));
+        } else {
+          dispatch(receiveFacilityFailure());
+        }
+      })
+      .catch(error => {
+        dispatch(receiveFacilityFailure());
+      });
+  };
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -38,7 +38,7 @@ class App extends Component {
           <Switch>
             <Route exact path="/" render={() => <Home content={content()} />} />
             <Route path="/results" component={Results} />
-            <Route path="/details" component={Details} />
+            <Route path="/details/:frid" component={Details} />
             <Route
               path="/content/:pageId"
               render={() => <Content content={content()} />}

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,24 +2,18 @@ import React from 'react';
 import tw from 'tailwind.macro';
 import 'styled-components/macro';
 import { PropTypes } from 'prop-types';
-import qs from 'qs';
 import { Link } from 'react-router-dom';
 import { OutboundLink } from 'react-ga';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
+
+import { linkToFacility } from '../utils/misc';
 
 import { Button } from './Input';
 
 const StyledHeading = tw.div`flex justify-between`;
 const StyledAddress = tw.address`text-gray-700 not-italic`;
 const StyledCard = tw.li`shadow border rounded p-6 mb-6`;
-
-const linkToFacility = (frid, longitude, latitude) => {
-  return {
-    pathname: `/details/${frid}`,
-    search: qs.stringify({ sAddr: `${longitude}, ${latitude}` })
-  };
-};
 
 const renderService = service => {
   const { name, values } = service;

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,6 +2,7 @@ import React from 'react';
 import tw from 'tailwind.macro';
 import 'styled-components/macro';
 import { PropTypes } from 'prop-types';
+import qs from 'qs';
 import { Link } from 'react-router-dom';
 import { OutboundLink } from 'react-ga';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,6 +14,13 @@ const StyledHeading = tw.div`flex justify-between`;
 const StyledAddress = tw.address`text-gray-700 not-italic`;
 const StyledCard = tw.li`shadow border rounded p-6 mb-6`;
 
+const linkToFacility = (frid, longitude, latitude) => {
+  return {
+    pathname: `/details/${frid}`,
+    search: qs.stringify({ sAddr: `${longitude}, ${latitude}` })
+  };
+};
+
 const renderService = service => {
   const { name, values } = service;
   return (
@@ -22,9 +30,9 @@ const renderService = service => {
   );
 };
 
-const CardHeading = ({ frid, name1, name2, miles }) => (
+const CardHeading = ({ frid, name1, name2, miles, latitude, longitude }) => (
   <StyledHeading>
-    <Link to={{ pathname: '/details', state: { frid } }}>
+    <Link to={linkToFacility(frid, latitude, longitude)}>
       <h2 css={tw`mb-2`}>
         {name1}
         {name2 && (
@@ -93,12 +101,21 @@ const Card = props => {
     zip,
     services,
     phone,
-    website
+    website,
+    latitude,
+    longitude
   } = props;
 
   return (
     <StyledCard>
-      <CardHeading frid={frid} name1={name1} name2={name2} miles={miles} />
+      <CardHeading
+        frid={frid}
+        name1={name1}
+        name2={name2}
+        miles={miles}
+        latitude={latitude}
+        longitude={longitude}
+      />
       <CardAddress
         street1={street1}
         street2={street2}
@@ -109,7 +126,7 @@ const Card = props => {
       <CardDetails phone={phone} website={website} services={services} />
       <Button
         as={Link}
-        to={{ pathname: '/details', state: { frid } }}
+        to={linkToFacility(frid, latitude, longitude)}
         css={tw`print:hidden`}
         primary="true"
       >

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { PropTypes } from 'prop-types';
+import qs from 'qs';
 import { connect } from 'react-redux';
-import { Redirect, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,12 +14,31 @@ import {
 import { OutboundLink } from 'react-ga';
 import { Helmet } from 'react-helmet';
 
+import { handleReceiveFacility, destroyFacility } from '../actions/facility';
 import { reportFacility } from '../actions/facilities';
 
+import Error from './Error';
+import NoMatch from './NoMatch';
+import Loading from './Loading';
 import MapContainer from './Map/MapContainer';
 import { Button } from './Input';
 
 export class Details extends Component {
+  componentDidMount() {
+    const { handleReceiveFacility, location, match } = this.props;
+    const params = qs.parse(location.search, {
+      ignoreQueryPrefix: true
+    });
+
+    handleReceiveFacility(match.params.frid, params);
+  }
+
+  componentWillUnmount() {
+    const { destroyFacility } = this.props;
+
+    destroyFacility();
+  }
+
   returnToResults = () => {
     this.props.history.goBack();
   };
@@ -35,13 +55,24 @@ export class Details extends Component {
   );
 
   reportFacility = () => {
-    const { facility, reportFacility } = this.props;
-    reportFacility(facility.frid);
+    const { data, reportFacility } = this.props;
+    reportFacility(data.frid);
   };
 
   render() {
-    if (!this.props.facility) {
-      return <Redirect to="/" />;
+    const { loading, error, data } = this.props;
+    const hasResult = data && Object.keys(data).length > 0;
+
+    if (error) {
+      return <Error />;
+    }
+
+    if (!loading && !hasResult) {
+      return <NoMatch />;
+    }
+
+    if (loading || !hasResult) {
+      return <Loading />;
     }
 
     const {
@@ -55,7 +86,7 @@ export class Details extends Component {
       services,
       phone,
       website
-    } = this.props.facility;
+    } = data;
 
     return (
       <div className="container">
@@ -130,10 +161,7 @@ export class Details extends Component {
             <div css={tw`border-b pb-6 mb-6`}>
               <h2 css={tw`mb-4`}>Location</h2>
               <div css={tw`relative h-64 w-full mb-2`}>
-                <MapContainer
-                  rows={[this.props.facility]}
-                  singleMarker={true}
-                />
+                <MapContainer rows={[data]} singleMarker={true} />
               </div>
               <div css={tw`text-gray-700`}>
                 {street1}, {street2 && street2 + ','}
@@ -178,38 +206,41 @@ export class Details extends Component {
 }
 
 Details.propTypes = {
-  facility: PropTypes.shape({
-    frid: PropTypes.string.isRequired,
-    name1: PropTypes.string.isRequired,
-    name2: PropTypes.string,
-    miles: PropTypes.number,
-    street1: PropTypes.string.isRequired,
-    street2: PropTypes.string,
-    city: PropTypes.string.isRequired,
-    state: PropTypes.string.isRequired,
-    zip: PropTypes.string.isRequired,
-    services: PropTypes.array.isRequired,
-    phone: PropTypes.string.isRequired,
-    website: PropTypes.string
-  }),
-  isReported: PropTypes.bool
+  data: PropTypes.object.isRequired,
+  error: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
+  isReported: PropTypes.bool.isRequired,
+  reportFacility: PropTypes.func.isRequired,
+  handleReceiveFacility: PropTypes.func.isRequired,
+  destroyFacility: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
   reportFacility(frid) {
     dispatch(reportFacility(frid));
+  },
+
+  handleReceiveFacility(frid, params) {
+    dispatch(handleReceiveFacility(frid, params));
+  },
+
+  destroyFacility() {
+    dispatch(destroyFacility());
   }
 });
 
-const mapStateToProps = ({ facilities }, ownProps) => {
-  const { data, reported } = facilities;
-  const { rows } = data;
-  const facility =
-    rows && rows.find(({ frid }) => frid === ownProps.location.state.frid);
+const mapStateToProps = ({ facility, facilities }, ownProps) => {
+  const { data, error, loading } = facility;
+  const { reported } = facilities;
 
   return {
-    facility,
-    isReported: facility && reported.includes(facility.frid)
+    data,
+    error,
+    loading,
+    isReported: data && reported.includes(data.frid)
   };
 };
 

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -67,12 +67,12 @@ export class Details extends Component {
       return <Error />;
     }
 
-    if (!loading && !hasResult) {
-      return <NoMatch />;
+    if (loading) {
+      return <Loading />;
     }
 
-    if (loading || !hasResult) {
-      return <Loading />;
+    if (!loading && !hasResult) {
+      return <NoMatch />;
     }
 
     const {

--- a/src/components/Details.test.js
+++ b/src/components/Details.test.js
@@ -26,6 +26,7 @@ const testProps = {
   error: false,
   loading: false,
   isReported: false,
+  isInternalLink: false,
   reportFacility: jest.fn(),
   handleReceiveFacility: jest.fn(),
   destroyFacility: jest.fn(),
@@ -36,7 +37,7 @@ const testProps = {
 };
 
 describe('Details component', () => {
-  it('shows an error message if error prop is true', () => {
+  it('shows an error message if there is a problem fetching data', () => {
     const props = {
       ...testProps,
       error: true
@@ -45,7 +46,7 @@ describe('Details component', () => {
     expect(component.find(Error).length).toBe(1);
   });
 
-  it('shows a loading message if loading prop is true', () => {
+  it('shows a loading message while fetching data', () => {
     const props = {
       ...testProps,
       loading: true
@@ -75,6 +76,22 @@ describe('Details component', () => {
     reporttBtn.simulate('click');
 
     expect(reportFn.mock.calls.length).toBe(1);
+  });
+
+  it('shows back link if coming from a search results page', () => {
+    const props = {
+      ...testProps,
+      isInternalLink: true
+    };
+    const component = shallow(<Details {...props} />);
+
+    expect(component.find('.back-link').length).toBe(1);
+  });
+
+  it('hides back link if accessing facility directly', () => {
+    const component = shallow(<Details {...testProps} />);
+
+    expect(component.find('.back-link').length).toBe(0);
   });
 
   it('hides report facility button if facility has already been reported', () => {

--- a/src/components/Details.test.js
+++ b/src/components/Details.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Details } from './Details';
+import Error from './Error';
+import NoMatch from './NoMatch';
+import Loading from './Loading';
+
+const testProps = {
+  data: {
+    city: 'Tucson',
+    frid: '2037b07b2bfb78e1bdaf2b46dd94ceb41c2da1493e7c0c22796d82762c4cbb53',
+    miles: 5.57,
+    name1: 'My Treatment Facility',
+    name2: 'Tucson Northwest',
+    phone: '520-123-4376',
+    services: {
+      TC: { name: 'Type of Care', values: ['Substance use treatment'] }
+    },
+    state: 'AZ',
+    street1: '3295 West Desert Road',
+    street2: 'Suite 150',
+    website: 'http://www.mytreatmentfacility.com',
+    zip: '85741'
+  },
+  error: false,
+  loading: false,
+  isReported: false,
+  reportFacility: () => {},
+  handleReceiveFacility: () => {},
+  destroyFacility: () => {},
+  location: {},
+  match: {},
+  history: {},
+  frid: '12628952a59ffa4ab1ceed0db7c391715eabda9ab1b16745651dffc917af7602'
+};
+
+describe('Details component', () => {
+  it('shows an error message if error prop is true', () => {
+    const props = {
+      ...testProps,
+      error: true
+    };
+    const component = shallow(<Details {...props} />, {
+      disableLifecycleMethods: true
+    });
+    expect(component.find(Error).length).toBe(1);
+  });
+
+  it('shows a loading message if loading prop is true', () => {
+    const props = {
+      ...testProps,
+      loading: true
+    };
+    const component = shallow(<Details {...props} />, {
+      disableLifecycleMethods: true
+    });
+    expect(component.find(Loading).length).toBe(1);
+  });
+
+  it('shows a a not found message when there are no results', () => {
+    const props = {
+      ...testProps,
+      data: {}
+    };
+    const component = shallow(<Details {...props} />, {
+      disableLifecycleMethods: true
+    });
+    expect(component.find(NoMatch).length).toBe(1);
+  });
+
+  it('calls reportFacility() when report facility button is clicked', () => {
+    const reportFn = jest.fn();
+    const props = {
+      ...testProps,
+      reportFacility: reportFn
+    };
+    const component = shallow(<Details {...props} />, {
+      disableLifecycleMethods: true
+    });
+    const reporttBtn = component.find('.report-facility');
+
+    reporttBtn.simulate('click');
+
+    expect(reportFn.mock.calls.length).toBe(1);
+  });
+
+  it('hides report facility button if facility has already been reported', () => {
+    const props = {
+      ...testProps,
+      isReported: true
+    };
+    const component = shallow(<Details {...props} />, {
+      disableLifecycleMethods: true
+    });
+
+    expect(component.find('.report-facility').length).toBe(0);
+  });
+});

--- a/src/components/Details.test.js
+++ b/src/components/Details.test.js
@@ -26,11 +26,11 @@ const testProps = {
   error: false,
   loading: false,
   isReported: false,
-  reportFacility: () => {},
-  handleReceiveFacility: () => {},
-  destroyFacility: () => {},
+  reportFacility: jest.fn(),
+  handleReceiveFacility: jest.fn(),
+  destroyFacility: jest.fn(),
   location: {},
-  match: {},
+  match: { params: {} },
   history: {},
   frid: '12628952a59ffa4ab1ceed0db7c391715eabda9ab1b16745651dffc917af7602'
 };
@@ -41,9 +41,7 @@ describe('Details component', () => {
       ...testProps,
       error: true
     };
-    const component = shallow(<Details {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<Details {...props} />);
     expect(component.find(Error).length).toBe(1);
   });
 
@@ -52,9 +50,7 @@ describe('Details component', () => {
       ...testProps,
       loading: true
     };
-    const component = shallow(<Details {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<Details {...props} />);
     expect(component.find(Loading).length).toBe(1);
   });
 
@@ -63,9 +59,7 @@ describe('Details component', () => {
       ...testProps,
       data: {}
     };
-    const component = shallow(<Details {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<Details {...props} />);
     expect(component.find(NoMatch).length).toBe(1);
   });
 
@@ -75,9 +69,7 @@ describe('Details component', () => {
       ...testProps,
       reportFacility: reportFn
     };
-    const component = shallow(<Details {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<Details {...props} />);
     const reporttBtn = component.find('.report-facility');
 
     reporttBtn.simulate('click');
@@ -90,9 +82,7 @@ describe('Details component', () => {
       ...testProps,
       isReported: true
     };
-    const component = shallow(<Details {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<Details {...props} />);
 
     expect(component.find('.report-facility').length).toBe(0);
   });

--- a/src/components/Map/InfoWindowText.js
+++ b/src/components/Map/InfoWindowText.js
@@ -3,23 +3,28 @@ import 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { OutboundLink } from 'react-ga';
 import { Link } from 'react-router-dom';
+
+import { linkToFacility } from '../../utils/misc';
+
 import { Button } from '../Input';
 
 export const InfoWindowText = props => {
   const { selectedPlace, singleMarker } = props;
+  const { details } = selectedPlace;
+  const { name1, phone, frid, latitude, longitude } = details;
 
   return (
     <>
       <h4 className="infowindow__heading" css={tw`mb-2 font-bold`}>
-        {selectedPlace.details.name1}
+        {name1}
       </h4>
       <p css={tw`font-normal mb-4`}>
         Phone:{' '}
         <OutboundLink
-          to={`tel:${selectedPlace.details.phone}`}
+          to={`tel:${phone}`}
           eventLabel="Facility phone link from map"
         >
-          {selectedPlace.details.phone}
+          {phone}
         </OutboundLink>
       </p>
       {!singleMarker && (
@@ -27,10 +32,7 @@ export const InfoWindowText = props => {
           as={Link}
           css={tw`p-1 w-full`}
           primary="true"
-          to={{
-            pathname: '/details',
-            state: { frid: selectedPlace.details.frid }
-          }}
+          to={linkToFacility(frid, latitude, longitude)}
         >
           View provider details
         </Button>

--- a/src/reducers/facility.js
+++ b/src/reducers/facility.js
@@ -1,0 +1,55 @@
+import {
+  RECEIVE_FACILITY_BEGIN,
+  RECEIVE_FACILITY_SUCCESS,
+  RECEIVE_FACILITY_FAILURE,
+  DESTROY_FACILITY
+} from '../actions/facility';
+import { servicesToObject } from '../utils/misc';
+
+const initialState = {
+  data: {},
+  loading: false,
+  error: false
+};
+
+export default function facility(state = initialState, action) {
+  switch (action.type) {
+    case RECEIVE_FACILITY_BEGIN:
+      return {
+        ...state,
+        data: {},
+        loading: true,
+        error: false
+      };
+    case RECEIVE_FACILITY_SUCCESS:
+      return {
+        ...state,
+        data: {
+          ...action.payload.data.rows
+            .filter(({ frid }) => frid === action.frid)
+            .map(facility => ({
+              ...facility,
+              services: servicesToObject(facility.services)
+            }))[0]
+        },
+        loading: false,
+        error: false
+      };
+    case RECEIVE_FACILITY_FAILURE:
+      return {
+        ...state,
+        data: {},
+        loading: false,
+        error: true
+      };
+    case DESTROY_FACILITY:
+      return {
+        ...state,
+        data: {},
+        loading: false,
+        error: false
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 import { reducer as formReducer } from 'redux-form';
 import languages from './languages';
+import facility from './facility';
 import facilities from './facilities';
 import clearAdvancedFilters from '../plugins/filters';
 
@@ -11,6 +12,7 @@ export default history =>
   combineReducers({
     router: connectRouter(history),
     languages,
+    facility,
     facilities,
     form: extendedForm
   });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,6 +4,7 @@ export const DEFAULT_DISTANCE = 25 * metersPerMile; // Radius from lat/long in m
 export const DEFAULT_PAGE_SIZE = 10; // Results returned with each request
 export const DEFAULT_LIMIT_TYPE = 2; // 0 = State, 1 = County, 2 = Distance
 export const DEFAULT_SORT = 0; // 0 = Distance: Low to High
+export const DEFAULT_STYPE = 'BOTH';
 export const HELPLINE_TEXT = '1-800-662-HELP (4357)';
 export const HELPLINE_LINK = '+1-800-662-4357';
 export const SITE_TITLE = 'Treatment Finder';

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,3 +1,5 @@
+import qs from 'qs';
+
 export const convertToSlug = string =>
   string
     .toLowerCase()
@@ -23,3 +25,10 @@ export const servicesToObject = array =>
     obj[item['f2']] = { name: item['f1'], values: item['f3'].split('; ') };
     return obj;
   }, {});
+
+export const linkToFacility = (frid, longitude, latitude) => {
+  return {
+    pathname: `/details/${frid}`,
+    search: qs.stringify({ sAddr: `${longitude}, ${latitude}` })
+  };
+};


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/146

Piggybacking off of @keithnorm's workaround here: https://github.com/18F/samhsa-prototype/pull/180 this adds the ability to navigate directly to a facility page, enabling folks to share/bookmark specific facilities.

By using a path of `/details/:frid/` along with the lat and long appended as query parameters, we are able to use the existing endpoint to search by lat/long (limiting results to only facilities with the exact lat/long), and then further filter by FRID in order to narrow the results to a single facility. This is accomplished with a single call to the endpoint.

In the future, if a new FRID specific endpoint is enabled, the `/details/:frid/` path can continued to be used (preserving existing links), and the additional query params can be dropped off.

The main caveat of this approach is that the links are dependent on the lat/long. If a facility's lat/long changes, the previous URL of the facility will no longer function.