### PR TITLE
Temporary fix for automatic filtering

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -337,14 +337,13 @@ export default connect(
     enableReinitialize: true,
     destroyOnUnmount: false,
     onChange: (values, dispatch, props, previousValues) => {
-      const { dirty, isDesktop } = props;
+      const { isDesktop } = props;
 
       if (!isDesktop) {
         return;
       }
 
-      // Only submit if form data has changed from its initialized values
-      dirty && dispatch(submit('filters'));
+      dispatch(submit('filters'));
     }
   })(FormFilters)
 );


### PR DESCRIPTION
When initiating a search from the homepage, a facility search is kicked off, but for one reason or another the search is kicked off a second time when the filter form is loaded on the results page (presumably because initializing the location field with the homepage value is triggering a change).

I attempted to use the `dirty` prop to prevent this from happening, but it was having some unintended consequences. `dirty` checks to see if any of the values are different from the initialized values, which works, until you return a value to it's initial value (like setting distance to 50mi, then back to the original 25mi) which will not load in new results.

Removing the `dirty` prop for now will make filtering more predictable, however I will circle back in another PR to figure out why the search is conducted twice when coming form the homepage.