### PR TITLE
Prevent empty location value in filter input

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -337,13 +337,13 @@ export default connect(
     enableReinitialize: true,
     destroyOnUnmount: false,
     onChange: (values, dispatch, props, previousValues) => {
-      const { isDesktop } = props;
+      const { isDesktop, loading } = props;
 
-      if (!isDesktop) {
+      if (!isDesktop || loading || !values.location) {
         return;
       }
 
-      !props.loading && dispatch(submit('filters'));
+      dispatch(submit('filters'));
     }
   })(FormFilters)
 );

--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -59,12 +59,12 @@ const StyledLocation = styled.div`
 `;
 
 class Location extends Component {
-  handleBlur = () => {
+  handleBlur = value => {
     this._geoSuggest.selectSuggest();
   };
 
   handleSuggest = suggest => {
-    this.props.input.onChange(suggest || '');
+    this.props.input.onChange(suggest || null);
   };
 
   handleNoResults = () => {


### PR DESCRIPTION
Sending an empty location causes a server error on the production endpoint. This can be seen in the steps outlined in https://github.com/18F/samhsa-prototype/issues/226. This prevents the filters form from submitting without a valid location.

I think there are definitely some bigger UX issues/questions associated with default/empty location behavior though that will need to be explored/tested more thoroughly.