### PR TITLE
Remove MH results from prototype

### DIFF
--- a/src/components/Header/HeaderBeta.js
+++ b/src/components/Header/HeaderBeta.js
@@ -7,7 +7,8 @@ const HeaderBeta = () => {
   return (
     <div css={tw`bg-yellow-300`}>
       <div className="container" css={tw`py-4 font-bold`}>
-        We are testing a new design for our treatment locator. Have feedback?{' '}
+        We are testing a new design for our substance use treatment locator.
+        Have feedback?{' '}
         <OutboundLink
           eventLabel="Header feedback form link"
           to="https://forms.gle/35ZHQCGBkxCsJcs78"

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -62,8 +62,8 @@ class Home extends Component {
               Find help near you
             </h1>
             Quickly find providers who treat{' '}
-            <strong>substance use disorders</strong>, <strong>addiction</strong>
-            , and <strong>mental illness.</strong>
+            <strong>substance use disorders</strong> and{' '}
+            <strong>addiction</strong>.
           </div>
           <div css={tw`lg:max-w-2xl lg:mx-auto mb-10`}>
             <FormHomepage onSubmit={this.submit} />

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 import {
   DEFAULT_PAGE_SIZE,
   DEFAULT_LIMIT_TYPE,
-  DEFAULT_SORT
+  DEFAULT_SORT,
+  DEFAULT_STYPE
 } from './constants';
 
 export default axios.create({
@@ -18,7 +19,7 @@ export const buildParams = query => {
   const serviceCodes = Object.values(sCodes);
 
   const params = {
-    sType: setServiceType(type),
+    sType: DEFAULT_STYPE,
     sCodes: combineServiceTypeAndServiceCodes(type, serviceCodes),
     pageSize: DEFAULT_PAGE_SIZE,
     page: page || 1,
@@ -45,31 +46,4 @@ const combineServiceTypeAndServiceCodes = (type = '', serviceCodes = []) => {
         .concat(type)
         .filter(code => !!code)
         .toString();
-};
-
-const serviceTypes = {
-  SUBSTANCE_USE: 'SA', // Substance use only
-  MENTAL_HEALTH: 'MH', // Mental health only
-  BOTH: 'BOTH' // Subtance use and mental health
-};
-
-const serviceCodes = {
-  MENTAL_HEALTH: 'Custom-Mental_Health', // Mental health services only
-  PSYCHIATRIC_WALK_IN: 'WI', // Psychiatric emergency walk-in services
-  CO_OCCURRING: 'CO' // Co-occurring mental health and substance use treatment
-};
-
-const setServiceType = (type = '') => {
-  if (
-    type.toLowerCase() === serviceCodes.MENTAL_HEALTH.toLowerCase() ||
-    type === serviceCodes.PSYCHIATRIC_WALK_IN
-  ) {
-    return serviceTypes.MENTAL_HEALTH;
-  }
-
-  if (type === serviceCodes.CO_OCCURRING) {
-    return serviceTypes.BOTH;
-  }
-
-  return serviceTypes.SUBSTANCE_USE;
 };

--- a/src/utils/api.test.js
+++ b/src/utils/api.test.js
@@ -90,36 +90,4 @@ describe('buildParams()', () => {
     };
     expect(buildParams(query)).toStrictEqual(testProps);
   });
-
-  it('sets sType:MH, and sCode:WI if Psychiatric emergency walk-in services is chosen', () => {
-    const query = {
-      type: 'WI'
-    };
-    expect(buildParams(query)).toStrictEqual({
-      ...testProps,
-      sType: 'MH',
-      sCodes: 'WI'
-    });
-  });
-
-  it('sets sType:BOTH, and sCode:CO if Co-occurring is chosen', () => {
-    const query = {
-      type: 'CO'
-    };
-    expect(buildParams(query)).toStrictEqual({
-      ...testProps,
-      sType: 'BOTH',
-      sCodes: 'CO'
-    });
-  });
-
-  it('sets sType:MH if Mental health services only is chosen', () => {
-    const query = {
-      type: 'Custom-Mental_Health'
-    };
-    expect(buildParams(query)).toStrictEqual({
-      ...testProps,
-      sType: 'MH'
-    });
-  });
 });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,7 +4,7 @@ export const DEFAULT_DISTANCE = 25 * metersPerMile; // Radius from lat/long in m
 export const DEFAULT_PAGE_SIZE = 10; // Results returned with each request
 export const DEFAULT_LIMIT_TYPE = 2; // 0 = State, 1 = County, 2 = Distance
 export const DEFAULT_SORT = 0; // 0 = Distance: Low to High
-export const DEFAULT_STYPE = 'BOTH';
+export const DEFAULT_STYPE = 'SA';
 export const HELPLINE_TEXT = '1-800-662-HELP (4357)';
 export const HELPLINE_LINK = '+1-800-662-4357';
 export const SITE_TITLE = 'Treatment Finder';

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -651,30 +651,6 @@ export default () => [
               also help people with very serious disorders who have been unable
               to get and stay sober or drug free in other treatment.
             </p>
-            <h3>Psychiatric Emergency Walk-in Services</h3>
-            <p>
-              <em>
-                Walk-in help for urgent/emergency mental health evaluation
-              </em>
-            </p>
-            <p>
-              These facilities focus on resolving a mental health crisis in a
-              less intensive setting than a hospital, though they may recommend
-              hospitalization when appropriate.
-            </p>
-            <h3>Telemedicine (including internet and mobile options)</h3>
-            <p>
-              <em>
-                Care given over the phone or online to support treatment and
-                recovery
-              </em>
-            </p>
-            <p>
-              Telemedicine can be a tremendous help to people who are unable to
-              regularly get to a treatment facility. While it’s not the first
-              step in treatment, telemedicine can be a key part of a treatment
-              plan, especially for patients living far away from a facility.
-            </p>
             <h3>Co-occurring mental health and substance use treatment</h3>
             <p>
               <em>
@@ -693,21 +669,18 @@ export default () => [
               treat the whole person, and ensure that treatment for one factor
               doesn’t interfere with treatment of others.
             </p>
-            <h3>Mental health services</h3>
+            <h3>Telemedicine (including internet and mobile options)</h3>
             <p>
-              <em>Treatment specifically for mental illness</em>
+              <em>
+                Care given over the phone or online to support treatment and
+                recovery
+              </em>
             </p>
             <p>
-              Mental illness can be hard to pinpoint, but getting a diagnosis
-              and treatment can help return to stability. Mental health care
-              facilities offer a range of behavioral health and therapy
-              practices, but all of them can help you determine what would be
-              the right fit for your situation.
-            </p>
-            <p>
-              These facilities might not have care for substance use disorders
-              or addiction. Be sure to ask when you call if you need this kind
-              of care.
+              Telemedicine can be a tremendous help to people who are unable to
+              regularly get to a treatment facility. While it’s not the first
+              step in treatment, telemedicine can be a key part of a treatment
+              plan, especially for patients living far away from a facility.
             </p>
           </>
         )

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -48,17 +48,12 @@ export const type = [
   { value: 'OP', label: 'Outpatient' },
   { value: 'HI', label: 'Hospital inpatient' },
   { value: 'RES', label: 'Residential' },
-  { value: 'WI', label: 'Psychiatric emergency walk-in services' },
-  {
-    value: 'CT',
-    label: 'Telemedicine (including internet and mobile programs)'
-  },
   {
     value: 'CO',
     label: 'Co-occurring mental health and substance use treatment'
   },
   {
-    value: 'Custom-Mental_Health',
-    label: 'Mental health services only'
+    value: 'CT',
+    label: 'Telemedicine (including internet and mobile programs)'
   }
 ];


### PR DESCRIPTION
Updates based on #214 

- Changed subtitle on home page to "Quickly find providers who treat substance use disorders and addiction" (remove mental illness)
- Removed 'mental health services only' and 'psychiatric emergency walk-in' from info content Treatment Options > Types of treatment
- Added SU-specific wording to beta banner
- Removed 'mental health services only' and 'psychiatric emergency walk-in' filters

NOTE: @hursey013 -We still need to:
- Change the co-occuring filter so that it returns SA only
- Make any other endpoint logic changes necessary (ensuring only SA facilities are returned globally)