### PR TITLE
Respect default distance when navigating directly to /results

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -14,7 +14,6 @@ import {
 
 import { handleReceiveLanguages } from '../../actions/languages';
 import { resetAdvancedFilters, resetAllFilters } from '../../actions/filters';
-import { handleReceiveFacilities } from '../../actions/facilities';
 import * as filterOptions from '../../utils/filters';
 import { LOCATION_WARNING } from '../../utils/warnings';
 
@@ -39,6 +38,7 @@ const Form = styled.form`
 export class FormFilters extends Component {
   componentDidMount() {
     const { dispatch } = this.props;
+
     dispatch(handleReceiveLanguages());
   }
 
@@ -67,12 +67,7 @@ export class FormFilters extends Component {
   };
 
   handleReset = () => {
-    const { resetAllFilters, initialValues, location } = this.props;
-
-    resetAllFilters({
-      distance: initialValues.distance,
-      location
-    });
+    this.props.resetAllFilters();
   };
 
   render() {
@@ -324,9 +319,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(resetAdvancedFilters());
   },
 
-  resetAllFilters(query) {
+  resetAllFilters() {
     dispatch(resetAllFilters());
-    dispatch(handleReceiveFacilities(query));
   }
 });
 

--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -304,14 +304,16 @@ FormFilters.propTypes = {
 const mapStateToProps = state => {
   const { languages } = state;
   const { loading, data } = languages;
-  const locationValue =
-    getFormValues('homepage')(state) || getFormValues('filters')(state);
+  const values =
+    getFormValues('homepage')(state) ||
+    getFormValues('filters')(state) ||
+    state.form.filters.initialValues;
 
   return {
     initialValues: {
-      ...locationValue
+      ...values
     },
-    location: locationValue && locationValue.location,
+    location: values && values.location,
     loading,
     data
   };

--- a/src/components/Form/FormHomepage.js
+++ b/src/components/Form/FormHomepage.js
@@ -84,7 +84,7 @@ const mapStateToProps = state => {
 
   return {
     initialValues: {
-      ...state.form.filters
+      ...state.form.filters.initialValues
     },
     location: values && values.location
   };

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -2,7 +2,9 @@ import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
 import { ADVANCED_FILTERS, DEFAULT_DISTANCE } from '../utils/constants';
 
 const initialFilterState = {
-  distance: DEFAULT_DISTANCE
+  initialValues: {
+    distance: DEFAULT_DISTANCE
+  }
 };
 
 const advancedFilters = ADVANCED_FILTERS;
@@ -31,7 +33,10 @@ export default {
       case RESET_ALL_FILTERS: {
         return {
           ...state,
-          values: { ...initialFilterState, location: state.values.location }
+          values: {
+            ...initialFilterState.initialValues,
+            location: state.values.location
+          }
         };
       }
       default:

--- a/src/plugins/filters.test.js
+++ b/src/plugins/filters.test.js
@@ -3,7 +3,9 @@ import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
 import { DEFAULT_DISTANCE } from '../utils/constants';
 
 const initialState = {
-  distance: DEFAULT_DISTANCE
+  initialValues: {
+    distance: DEFAULT_DISTANCE
+  }
 };
 
 describe('filters reducer', () => {
@@ -85,7 +87,7 @@ describe('filters reducer', () => {
     ).toEqual({
       ...initialState,
       values: {
-        ...initialState,
+        ...initialState.initialValues,
         location: {
           description: 'Tempe, AZ, USA',
           isFixture: false,


### PR DESCRIPTION
Currently, when navigating directly to `/results` the distance dropdown is unset and shows `100+ miles`. This updates the logic to use the defined default distance.