### PR TITLE
Check for filter values in proper order

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -310,8 +310,8 @@ const mapStateToProps = state => {
   const { languages } = state;
   const { loading, data } = languages;
   const values =
-    getFormValues('homepage')(state) ||
     getFormValues('filters')(state) ||
+    getFormValues('homepage')(state) ||
     state.form.filters.initialValues;
 
   return {


### PR DESCRIPTION
When the results page is loaded, it should look for filter values in the following order:

- If there are existing values already set in the filters form
- If not, check if there are values being sent from the homepage
- If no values are set at all, use the `initialValues` object to initialize the form

Previously, the first two bullet points were switched, causing stale homepage values to override values set in the filters themselves.

To replicate:
> when I filter by 'type of treatment' & change distance, and then view provider details on any facility card, and then click on 'back to search results' - the distance resets to 25 and the type of treatment changes to the blank default, but I think it is still keeping my original search query. Is there any way to keep the search criteria people put in?