### PR TITLE
Improve filter interaction based on feedback

### DIFF
--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -1,10 +1,5 @@
-export const RESET_ADVANCED_FILTERS = 'RESET_ADVANCED_FILTERS';
 export const RESET_ALL_FILTERS = 'RESET_ALL_FILTERS';
 
 export const resetAllFilters = () => ({
   type: RESET_ALL_FILTERS
-});
-
-export const resetAdvancedFilters = () => ({
-  type: RESET_ADVANCED_FILTERS
 });

--- a/src/actions/filters.test.js
+++ b/src/actions/filters.test.js
@@ -1,20 +1,9 @@
-import {
-  RESET_ALL_FILTERS,
-  RESET_ADVANCED_FILTERS,
-  resetAllFilters,
-  resetAdvancedFilters
-} from './filters';
+import { RESET_ALL_FILTERS, resetAllFilters } from './filters';
 
 describe('action creators', () => {
   it('creates the resetAllFilters action', () => {
     const expected = { type: RESET_ALL_FILTERS };
 
     expect(resetAllFilters()).toEqual(expected);
-  });
-
-  it('creates the resetAdvancedFilter action', () => {
-    const expected = { type: RESET_ADVANCED_FILTERS };
-
-    expect(resetAdvancedFilters()).toEqual(expected);
   });
 });

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,0 +1,5 @@
+export const TOGGLE_ADVANCED_FILTERS = 'TOGGLE_ADVANCED_FILTERS';
+
+export const toggleAdvancedFilters = () => ({
+  type: TOGGLE_ADVANCED_FILTERS
+});

--- a/src/actions/ui.test.js
+++ b/src/actions/ui.test.js
@@ -1,0 +1,9 @@
+import { TOGGLE_ADVANCED_FILTERS, toggleAdvancedFilters } from './ui';
+
+describe('action creators', () => {
+  it('creates the toggleAdvancedFilters action', () => {
+    const expected = { type: TOGGLE_ADVANCED_FILTERS };
+
+    expect(toggleAdvancedFilters()).toEqual(expected);
+  });
+});

--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -13,7 +13,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import { handleReceiveLanguages } from '../../actions/languages';
-import { resetAdvancedFilters, resetAllFilters } from '../../actions/filters';
+import { resetAllFilters } from '../../actions/filters';
+import { toggleAdvancedFilters } from '../../actions/ui';
 import * as filterOptions from '../../utils/filters';
 import { LOCATION_WARNING } from '../../utils/warnings';
 
@@ -45,7 +46,6 @@ export class FormFilters extends Component {
   }
 
   state = {
-    isHidden: true,
     showLocationWarning: false
   };
 
@@ -55,17 +55,8 @@ export class FormFilters extends Component {
     });
   };
 
-  toggleHidden = () => {
-    this.setState(
-      {
-        isHidden: !this.state.isHidden
-      },
-      () => {
-        if (this.state.isHidden) {
-          this.props.resetAdvancedFilters();
-        }
-      }
-    );
+  toggleAdvancedFilters = () => {
+    this.props.toggleAdvancedFilters();
   };
 
   handleReset = () => {
@@ -74,6 +65,7 @@ export class FormFilters extends Component {
 
   render() {
     const {
+      advancedHidden,
       handleSubmit,
       languages,
       toggleFilters,
@@ -83,7 +75,7 @@ export class FormFilters extends Component {
       hasResults,
       isDesktop
     } = this.props;
-    const { isHidden, showLocationWarning } = this.state;
+    const { showLocationWarning } = this.state;
 
     return (
       <>
@@ -193,7 +185,7 @@ export class FormFilters extends Component {
                 />
               </Label>
             </Row>
-            {!this.state.isHidden && (
+            {!advancedHidden && (
               <div className="filter-container">
                 <Row>
                   <Label value="Ages accepted">
@@ -262,12 +254,12 @@ export class FormFilters extends Component {
             <button
               className="filter-link"
               css={tw`mb-6`}
-              onClick={this.toggleHidden}
+              onClick={this.toggleAdvancedFilters}
               type="button"
             >
-              {isHidden ? 'More' : 'Less'} filters
+              {advancedHidden ? 'More' : 'Less'} filters
               <FontAwesomeIcon
-                icon={isHidden ? faAngleDown : faAngleUp}
+                icon={advancedHidden ? faAngleDown : faAngleUp}
                 css={tw`text-blue-500 ml-1`}
               />
             </button>
@@ -292,6 +284,7 @@ export class FormFilters extends Component {
 }
 
 FormFilters.propTypes = {
+  advancedHidden: PropTypes.bool.isRequired,
   languages: PropTypes.array.isRequired,
   dispatch: PropTypes.func.isRequired,
   filtersHidden: PropTypes.bool.isRequired,
@@ -299,7 +292,7 @@ FormFilters.propTypes = {
   hasResults: PropTypes.bool.isRequired,
   initialValues: PropTypes.object.isRequired,
   isDesktop: PropTypes.bool.isRequired,
-  resetAdvancedFilters: PropTypes.func.isRequired,
+  toggleAdvancedFilters: PropTypes.func.isRequired,
   resetAllFilters: PropTypes.func.isRequired,
   resultsHidden: PropTypes.bool.isRequired,
   toggleFilters: PropTypes.func.isRequired,
@@ -307,14 +300,16 @@ FormFilters.propTypes = {
 };
 
 const mapStateToProps = state => {
-  const { languages } = state;
+  const { languages, ui } = state;
   const { loading, data } = languages;
+  const { advancedHidden } = ui;
   const values =
     getFormValues('filters')(state) ||
     getFormValues('homepage')(state) ||
     state.form.filters.initialValues;
 
   return {
+    advancedHidden,
     initialValues: {
       ...values
     },
@@ -324,8 +319,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  resetAdvancedFilters() {
-    dispatch(resetAdvancedFilters());
+  toggleAdvancedFilters() {
+    dispatch(toggleAdvancedFilters());
   },
 
   resetAllFilters() {

--- a/src/components/Form/FormFilters.test.js
+++ b/src/components/Form/FormFilters.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { FormFilters } from './FormFilters';
 
 const testProps = {
+  advancedHidden: true,
   languages: [],
   dispatch: () => {},
   filtersHidden: false,
@@ -10,8 +11,7 @@ const testProps = {
   hasResults: true,
   initialValues: {},
   isDesktop: true,
-  location: {},
-  resetAdvancedFilters: () => {},
+  toggleAdvancedFilters: () => {},
   resetAllFilters: () => {},
   resultsHidden: false,
   toggleFilters: () => {},
@@ -19,40 +19,14 @@ const testProps = {
 };
 
 describe('Filters component', () => {
-  it('displays correct toggle link text', () => {
-    const component = shallow(<FormFilters {...testProps} />, {
-      disableLifecycleMethods: true
-    });
-    const toggleBtn = component.find('.filter-link');
-
-    expect(toggleBtn.text()).toBe('More filters');
-    toggleBtn.simulate('click');
-    expect(component.find('.filter-link').text()).toBe('Less filters');
-  });
-
-  it('toggle additional filter container', () => {
-    const component = shallow(<FormFilters {...testProps} />, {
-      disableLifecycleMethods: true
-    });
-    const toggleBtn = component.find('.filter-link');
-
-    expect(component.find('.filter-container').length).toBe(0);
-    toggleBtn.simulate('click');
-    expect(component.find('.filter-container').length).toBe(1);
-  });
-
-  it('calls resetAdvancedFilters method when filters are hidden', () => {
+  it('calls toggleAdvancedFilters() when filters are toggled', () => {
     const mockDispatch = jest.fn();
     const props = {
       ...testProps,
-      resetAdvancedFilters: mockDispatch
+      toggleAdvancedFilters: mockDispatch
     };
-    const component = shallow(<FormFilters {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<FormFilters {...props} />);
     const toggleBtn = component.find('.filter-link');
-
-    toggleBtn.simulate('click');
 
     expect(mockDispatch.mock.calls.length).toBe(0);
 
@@ -62,18 +36,16 @@ describe('Filters component', () => {
   });
 
   it('calls resetFilters() when reset filter button is clicked', () => {
-    const resetFn = jest.fn();
+    const mockDispatch = jest.fn();
     const props = {
       ...testProps,
-      resetAllFilters: resetFn
+      resetAllFilters: mockDispatch
     };
-    const component = shallow(<FormFilters {...props} />, {
-      disableLifecycleMethods: true
-    });
+    const component = shallow(<FormFilters {...props} />);
     const resetBtn = component.find('.reset-filters');
 
     resetBtn.simulate('click');
 
-    expect(resetFn.mock.calls.length).toBe(1);
+    expect(mockDispatch.mock.calls.length).toBe(1);
   });
 });

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -1,5 +1,5 @@
-import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
-import { ADVANCED_FILTERS, DEFAULT_DISTANCE } from '../utils/constants';
+import { RESET_ALL_FILTERS } from '../actions/filters';
+import { DEFAULT_DISTANCE } from '../utils/constants';
 
 const initialFilterState = {
   initialValues: {
@@ -8,29 +8,9 @@ const initialFilterState = {
   }
 };
 
-const advancedFilters = ADVANCED_FILTERS;
-const resetFilters = values => {
-  return Object.entries(values).reduce((memo, [key, value]) => {
-    if (advancedFilters.includes(key)) {
-      return memo;
-    }
-
-    return {
-      ...memo,
-      [key]: value
-    };
-  }, {});
-};
-
 export default {
   filters(state = initialFilterState, action) {
     switch (action.type) {
-      case RESET_ADVANCED_FILTERS: {
-        return {
-          ...state,
-          values: resetFilters(state.values)
-        };
-      }
       case RESET_ALL_FILTERS: {
         return {
           ...state,

--- a/src/plugins/filters.test.js
+++ b/src/plugins/filters.test.js
@@ -1,5 +1,5 @@
 import reducer from './filters';
-import { RESET_ADVANCED_FILTERS, RESET_ALL_FILTERS } from '../actions/filters';
+import { RESET_ALL_FILTERS } from '../actions/filters';
 import { DEFAULT_DISTANCE } from '../utils/constants';
 
 const initialState = {
@@ -12,50 +12,6 @@ const initialState = {
 describe('filters reducer', () => {
   it('should return the initial state', () => {
     expect(reducer.filters(undefined, {})).toEqual(initialState);
-  });
-
-  it('should handle RESET_ADVANCED_FILTERS', () => {
-    expect(
-      reducer.filters(
-        {
-          ...initialState,
-          values: {
-            GL: 'GL',
-            VET: 'VET',
-            age: 'ADLT',
-            distance: '40233.6',
-            language: 'SP-Spanish',
-            location: {
-              address: 'Tempe, AZ, USA',
-              latLng: {
-                lat: 33.4255104,
-                lng: -111.94000540000002
-              }
-            },
-            mat: 'BU',
-            payment: 'MD',
-            type: 'OP'
-          }
-        },
-        {
-          type: RESET_ADVANCED_FILTERS
-        }
-      )
-    ).toEqual({
-      ...initialState,
-      values: {
-        distance: '40233.6',
-        location: {
-          address: 'Tempe, AZ, USA',
-          latLng: {
-            lat: 33.4255104,
-            lng: -111.94000540000002
-          }
-        },
-        payment: 'MD',
-        type: 'OP'
-      }
-    });
   });
 
   it('should handle RESET_ALL_FILTERS', () => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 import { reducer as formReducer } from 'redux-form';
 import languages from './languages';
+import ui from './ui';
 import facility from './facility';
 import facilities from './facilities';
 import clearAdvancedFilters from '../plugins/filters';
@@ -12,6 +13,7 @@ export default history =>
   combineReducers({
     router: connectRouter(history),
     languages,
+    ui,
     facility,
     facilities,
     form: extendedForm

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,0 +1,18 @@
+import { TOGGLE_ADVANCED_FILTERS } from '../actions/ui';
+
+const initialState = {
+  advancedHidden: true
+};
+
+export default function languages(state = initialState, action) {
+  switch (action.type) {
+    case TOGGLE_ADVANCED_FILTERS: {
+      return {
+        ...state,
+        advancedHidden: !state.advancedHidden
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/reducers/ui.test.js
+++ b/src/reducers/ui.test.js
@@ -1,0 +1,22 @@
+import reducer from './ui';
+import { TOGGLE_ADVANCED_FILTERS } from '../actions/ui';
+
+const initialState = {
+  advancedHidden: true
+};
+
+describe('ui reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle TOGGLE_ADVANCED_FILTERS', () => {
+    expect(
+      reducer(initialState, {
+        type: TOGGLE_ADVANCED_FILTERS
+      })
+    ).toEqual({
+      advancedHidden: false
+    });
+  });
+});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,3 @@
-export const ADVANCED_FILTERS = ['age', 'language', 'VET', 'GL', 'mat'];
 const metersPerMile = 1609.344;
 export const DEFAULT_DISTANCE = 25 * metersPerMile; // Radius from lat/long in meters
 export const DEFAULT_PAGE_SIZE = 10; // Results returned with each request


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/265
Fixes https://github.com/18F/samhsa-prototype/issues/264

Moves the opened/closed state of the "more filters" section to the redux store in order to retain the current state while navigating to and from the results. Also removes logic which clears the values in "more filters" when section is collapsed.