### PR TITLE
Remove 'all types of treatment' option from MAT section

### DIFF
--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -17,6 +17,12 @@ export const distance = [
 
 export const mat = [
   {
+    value: '',
+    label: 'Show all facilities',
+    description:
+      'Includes facilities that do not offer medication-assisted treatment'
+  },
+  {
     value: 'METH',
     label: 'Methadone',
     description:

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -17,10 +17,6 @@ export const distance = [
 
 export const mat = [
   {
-    value: '',
-    label: 'All types of treatment'
-  },
-  {
     value: 'METH',
     label: 'Methadone',
     description:


### PR DESCRIPTION
We decided to remove the "all types of treatment" default option from the MAT filter section. It was confusing to people in usability tests. 

Resolves #293 