### PR TITLE
Filter enhancements

### DIFF
--- a/src/components/Input/Label.js
+++ b/src/components/Input/Label.js
@@ -5,14 +5,16 @@ import { PropTypes } from 'prop-types';
 import { Link } from 'react-router-dom';
 
 const StyledLabel = styled.label`
-  ${tw`block mb-2`}
+  ${tw`block mb-4`}
 
   ${props => props.inline && tw`flex`}
 
   span {
     ${tw`block font-bold font-heading uppercase text-sm mb-2`}
 
-    ${props => props.inline && tw`font-sans normal-case mb-0`}
+    ${props =>
+      props.inline &&
+      tw`font-sans normal-case leading-none mb-1 sm:leading-normal sm:-mt-px`}
 
     ${props => props.large && tw`normal-case text-2xl md:text-3xl`}
   }
@@ -28,14 +30,10 @@ const Label = props => {
       {props.inline ? (
         <StyledLabel {...props}>
           {props.children}
-          {props.description ? (
-            <div css={tw`-mt-px`}>
-              <span>{props.labelText}</span>
-              <p>{props.description}</p>
-            </div>
-          ) : (
+          <div css={tw``}>
             <span>{props.labelText}</span>
-          )}
+            {props.description && <p>{props.description}</p>}
+          </div>
         </StyledLabel>
       ) : (
         <StyledLabel {...props}>

--- a/src/components/Input/Label.js
+++ b/src/components/Input/Label.js
@@ -30,7 +30,7 @@ const Label = props => {
       {props.inline ? (
         <StyledLabel {...props}>
           {props.children}
-          <div css={tw``}>
+          <div>
             <span>{props.labelText}</span>
             {props.description && <p>{props.description}</p>}
           </div>

--- a/src/components/Input/Label.js
+++ b/src/components/Input/Label.js
@@ -20,7 +20,7 @@ const StyledLabel = styled.label`
   }
 
   p {
-    ${tw`text-sm`}
+    ${tw`text-sm text-gray-darker`}
   }
 `;
 

--- a/src/components/Input/Radio.js
+++ b/src/components/Input/Radio.js
@@ -1,15 +1,23 @@
 import React from 'react';
-import 'styled-components/macro';
+import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { PropTypes } from 'prop-types';
-
+import { theme } from '../../tailwind.js';
 import { Label } from '../Input';
+
+const Input = styled.input`
+  ${tw`mt-px mr-2 flex-none`}
+
+  transform: scale(1.25);
+  @media (min-width: ${theme.screens.sm}) {
+    transform: scale(1);
+  }
+`;
 
 const Radio = ({ input, option }) => {
   return (
     <Label labelText={option.label} description={option.description} inline>
-      <input
-        css={tw`mt-px mr-2 flex-none`}
+      <Input
         type="radio"
         {...input}
         value={option.value}


### PR DESCRIPTION
Resolves #330 

I believe this addresses everything but changing the color of the radio inputs. Per my comment on the issue, I am guessing that implementing custom inputs JUST to change the color is probably out of scope for the MVP...

Changing the size of the radio inputs on mobile is done with `transform: scale(1.25)`. This appears OK when viewing the "mobile" site in Mac Chrome, but needs some browser testing, especially on mobile, to make sure this is working as intended.