### PR TITLE
Add disabled attr to button when disabled

### DIFF
--- a/src/components/Input/Button.js
+++ b/src/components/Input/Button.js
@@ -6,25 +6,13 @@ import { PropTypes } from 'prop-types';
 import { theme } from '../../tailwind.js';
 
 const Button = styled(
-  ({
-    as,
-    children,
-    primary,
-    secondary,
-    outline,
-    gradient,
-    disabled,
-    link,
-    ...rest
-  }) =>
+  ({ as, children, primary, secondary, outline, gradient, link, ...rest }) =>
     as ? (
-      <Button as={as} disabled={disabled} {...rest}>
+      <Button as={as} {...rest}>
         {children}
       </Button>
     ) : (
-      <button disabled={disabled} {...rest}>
-        {children}
-      </button>
+      <button {...rest}>{children}</button>
     )
 )`
   ${tw`font-semibold py-2 px-4 rounded inline-flex items-center justify-center`}

--- a/src/components/Input/Button.js
+++ b/src/components/Input/Button.js
@@ -18,11 +18,13 @@ const Button = styled(
     ...rest
   }) =>
     as ? (
-      <Button as={as} {...rest}>
+      <Button as={as} disabled={disabled} {...rest}>
         {children}
       </Button>
     ) : (
-      <button {...rest}>{children}</button>
+      <button disabled={disabled} {...rest}>
+        {children}
+      </button>
     )
 )`
   ${tw`font-semibold py-2 px-4 rounded inline-flex items-center justify-center`}


### PR DESCRIPTION
Resolves #307 

Adds the `disabled` attribute to `Button`s when they are disabled.

@iamjolly I don't think this is your preferred approach, but this is MUCH quicker right now than showing the error message on submit of no data. If we still want to enhance this to use other behavior, perhaps we can roll it into #308 and reprioritize.