### PR TITLE
Modify conditional content for transportation callout.

### DIFF
--- a/src/components/Details/DetailsLocation.js
+++ b/src/components/Details/DetailsLocation.js
@@ -86,8 +86,13 @@ const DetailsLocation = props => {
               <strong>
                 {offersTransportation ? 'offers' : 'does not offer'}
               </strong>{' '}
-              transportation assistance. <br css={tw`hidden lg:block`} />
-              Ask them about it when you call.
+              transportation assistance.
+              {offersTransportation && (
+                <>
+                  <br css={tw`hidden lg:block`} /> Ask them about it when you
+                  call.
+                </>
+              )}
             </p>
           </div>
         </div>

--- a/src/components/Details/DetailsLocation.test.js
+++ b/src/components/Details/DetailsLocation.test.js
@@ -24,7 +24,7 @@ describe('DetailsLocation component', () => {
     const component = shallow(<DetailsLocation {...testProps} />);
 
     expect(component.find('.transportation-text').text()).toBe(
-      'This facility does not offer transportation assistance. Ask them about it when you call.'
+      'This facility does not offer transportation assistance.'
     );
   });
 


### PR DESCRIPTION
Removes the `Ask them about it when you call.` sentence when a facility does not offer transportation assistance.