### PR TITLE
Add info icon to before you call warning box

### DIFF
--- a/src/components/Warning.js
+++ b/src/components/Warning.js
@@ -4,7 +4,11 @@ import 'styled-components/macro';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleDown, faTimes } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAngleDown,
+  faInfoCircle,
+  faTimes
+} from '@fortawesome/free-solid-svg-icons';
 
 import { toggleWarning } from '../actions/ui';
 import { convertToSlug } from '../utils/misc';
@@ -26,7 +30,12 @@ class Warning extends Component {
           css={tw`flex items-center justify-between w-full`}
           aria-expanded={!isHidden}
         >
-          <span css={tw`block font-heading font-bold uppercase`}>
+          <span css={tw`font-heading font-bold uppercase flex items-center`}>
+            <FontAwesomeIcon
+              icon={faInfoCircle}
+              css={tw`mr-2 text-yellow`}
+              className="fa-lg"
+            />
             {heading}
           </span>
           <div css={tw`flex-none`}>


### PR DESCRIPTION
Add info-circle icon to warning box:

<img width="679" alt="Screen Shot 2019-09-26 at 10 16 18 AM" src="https://user-images.githubusercontent.com/1178494/65696225-db1db300-e046-11e9-8b95-568f53ef093a.png">
