### PR TITLE
Add small animation to mobile button when results are being retrieved

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -4,6 +4,7 @@ import styled from 'styled-components/macro';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { Field, reduxForm, getFormValues, reset, submit } from 'redux-form';
+import { ChasingDots } from 'styled-spinkit';
 
 import { handleReceiveLanguages } from '../../actions/languages';
 import * as filterOptions from '../../utils/filters';
@@ -39,7 +40,7 @@ export class FormFilters extends Component {
   };
 
   renderSubmitButton = () => {
-    const { location, recordCount, toggleFilters } = this.props;
+    const { loading, location, recordCount, toggleFilters } = this.props;
 
     return (
       <RowWrapper>
@@ -50,7 +51,13 @@ export class FormFilters extends Component {
             css={tw`w-full text-xl`}
             onClick={(location || {}).latLng && toggleFilters}
           >
-            Show {recordCount} results
+            Show{' '}
+            {loading ? (
+              <ChasingDots size={16} css={tw`mx-1 my-0`} color="#fff" />
+            ) : (
+              recordCount
+            )}{' '}
+            results
           </Button>
         </Row>
       </RowWrapper>
@@ -169,13 +176,14 @@ FormFilters.propTypes = {
   isDesktop: PropTypes.bool.isRequired,
   languages: PropTypes.array.isRequired,
   location: PropTypes.object,
+  loading: PropTypes.bool.isRequired,
   recordCount: PropTypes.number,
   resetForm: PropTypes.func.isRequired,
   toggleFilters: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
-  const { languages } = state;
+  const { facilities, languages } = state;
   const { data } = languages;
   const values = getFormValues('filters')(state);
 
@@ -185,7 +193,8 @@ const mapStateToProps = state => {
       location: { address: '' }
     },
     location: (values || {}).location,
-    languages: data
+    languages: data,
+    loading: facilities.loading
   };
 };
 

--- a/src/components/Form/FormFilters.test.js
+++ b/src/components/Form/FormFilters.test.js
@@ -9,6 +9,7 @@ const testProps = {
   isDesktop: true,
   languages: [],
   location: {},
+  loading: false,
   recordCount: 0,
   resetForm: jest.fn(),
   toggleFilters: jest.fn()
@@ -88,6 +89,34 @@ describe('FormFilters component', () => {
       form.simulate('submit');
 
       expect(props.handleSubmit.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('on mobile', () => {
+    it('shows an animation when loading results', () => {
+      const props = {
+        ...testProps,
+        isDesktop: false,
+        loading: true
+      };
+      const component = shallow(<FormFilters {...props} />);
+
+      expect(
+        component.find('FormFilters___StyledChasingDots').first().length
+      ).toBe(1);
+    });
+
+    it('hides animation once results have been retrieved', () => {
+      const props = {
+        ...testProps,
+        isDesktop: false,
+        loading: false
+      };
+      const component = shallow(<FormFilters {...props} />);
+
+      expect(
+        component.find('FormFilters___StyledChasingDots').first().length
+      ).toBe(0);
     });
   });
 


### PR DESCRIPTION
Smooths the transition when populating the button with the number of results on mobile.

**Preview:**
<img width="470" alt="Screen Shot 2019-09-26 at 11 33 38 AM" src="https://user-images.githubusercontent.com/1178494/65702887-c4c92480-e051-11e9-9770-abdfb19fb143.png">
