### PR TITLE
Fix homepage image width on IE Edge

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -103,7 +103,7 @@ class Home extends Component {
               {isDesktop && (
                 <img
                   src={backgroundLeft_2x}
-                  css={tw`px-8`}
+                  css={tw`px-8 w-auto flex-none`}
                   style={{ height: '336px' }}
                   alt=""
                 />
@@ -142,7 +142,7 @@ class Home extends Component {
               {isTablet && (
                 <img
                   src={backgroundRight_2x}
-                  css={tw`px-4 lg:px-8`}
+                  css={tw`px-4 lg:px-8 w-auto flex-none`}
                   style={{ height: '336px' }}
                   alt=""
                 />


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/313

Resolves an issue with how the images were rendering on the homepage in Edge.

Screenshot after fix:
<img width="755" alt="Screen Shot 2019-09-26 at 3 52 13 PM" src="https://user-images.githubusercontent.com/1178494/65720403-e0debd00-e075-11e9-89e6-b7ade24476ab.png">
