### PR TITLE
Remove block level elements from label

### DIFF
--- a/src/components/Input/Label.js
+++ b/src/components/Input/Label.js
@@ -9,7 +9,7 @@ const StyledLabel = styled.label`
 
   ${props => props.inline && tw`flex`}
 
-  span {
+  .label-text {
     ${tw`block font-bold font-heading uppercase text-sm mb-2`}
 
     ${props =>
@@ -30,22 +30,22 @@ const Label = props => {
       {props.inline ? (
         <StyledLabel {...props}>
           {props.children}
-          <div>
-            <span>{props.labelText}</span>
+          <span css={tw`block`}>
+            <span className="label-text">{props.labelText}</span>
             {props.description && <p>{props.description}</p>}
-          </div>
+          </span>
         </StyledLabel>
       ) : (
         <StyledLabel {...props}>
           {props.help ? (
-            <div css={tw`flex justify-between items-center`}>
-              <span>{props.labelText}</span>
+            <span css={tw`flex justify-between items-center`}>
+              <span className="label-text">>{props.labelText}</span>
               <Link to={props.help.url} css={tw`mb-2 text-sm`}>
                 {props.help.text}
               </Link>
-            </div>
+            </span>
           ) : (
-            <span>{props.labelText}</span>
+            <span className="label-text">{props.labelText}</span>
           )}
           {props.children}
         </StyledLabel>

--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -13,8 +13,8 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
 import { LOCATION_WARNING } from '../../utils/warnings';
 
-const StyledPlacesAutoComplete = styled.div`
-  ${tw`relative`}
+const StyledPlacesAutoComplete = styled.span`
+  ${tw`block relative`}
 
   input {
     ${tw`block w-full pr-8 text-lg`}
@@ -34,7 +34,7 @@ const StyledPlacesAutoComplete = styled.div`
   }
 
   .autocomplete-dropdown-container {
-    ${tw`absolute z-10 inset-x-0 overflow-x-hidden overflow-y-auto border border-gray rounded bg-white`}
+    ${tw`block absolute z-10 inset-x-0 overflow-x-hidden overflow-y-auto border border-gray rounded bg-white`}
     max-height: 25em;
     -webkit-transition: max-height 0.2s, border 0.2s;
     transition: max-height 0.2s, border 0.2s;
@@ -122,7 +122,7 @@ class Location extends Component {
         >
           {({ getInputProps, suggestions, getSuggestionItemProps }) => (
             <>
-              <div css={tw`relative`}>
+              <span css={tw`block relative`}>
                 <input
                   {...getInputProps({
                     className,
@@ -133,16 +133,16 @@ class Location extends Component {
                     ref: this.props.innerRef
                   })}
                 />
-                <div
+                <span
                   css={tw`absolute inset-y-0 right-0 flex items-center pr-4`}
                 >
                   <FontAwesomeIcon
                     icon={faSearch}
                     css={tw`fill-current w-6 h-6`}
                   />
-                </div>
+                </span>
                 {suggestions && suggestions.length > 0 && (
-                  <div
+                  <span
                     className="autocomplete-dropdown-container"
                     role="listbox"
                     id="listbox"
@@ -153,22 +153,23 @@ class Location extends Component {
                         ? 'suggestion-item suggestion-item--active'
                         : 'suggestion-item';
                       return (
-                        <div
+                        <span
+                          css={tw`block`}
                           {...getSuggestionItemProps(suggestion, {
                             className
                           })}
                         >
                           {suggestion.description}
-                        </div>
+                        </span>
                       );
                     })}
-                  </div>
+                  </span>
                 )}
-              </div>
+              </span>
               {this.state.showLocationWarning && (
-                <div css={tw`mt-2 text-red-light text-sm`}>
+                <span css={tw`block mt-2 text-red-light text-sm`}>
                   {LOCATION_WARNING}
-                </div>
+                </span>
               )}
             </>
           )}


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/315

Block level elements are not allowed in `<label />` so this removes them. Also, the second part of  https://github.com/18F/samhsa-prototype/issues/315, `value attribute not allowed on label element` has since been fixed in another PR.