### PR TITLE
Prevent duplicate searches

### DIFF
--- a/src/components/Form/FormFilters.js
+++ b/src/components/Form/FormFilters.js
@@ -29,16 +29,6 @@ export class FormFilters extends Component {
     }
   }
 
-  handleSubmit = submitEvent => {
-    const { handleSubmit, location } = this.props;
-
-    if (!(location || {}).latLng) {
-      return submitEvent.preventDefault();
-    }
-
-    handleSubmit(submitEvent);
-  };
-
   renderSubmitButton = () => {
     const { loading, location, recordCount, toggleFilters } = this.props;
 
@@ -65,7 +55,7 @@ export class FormFilters extends Component {
   };
 
   render() {
-    const { isDesktop, languages, resetForm } = this.props;
+    const { handleSubmit, isDesktop, languages, resetForm } = this.props;
 
     return (
       <div css={tw`bg-teal-lighter rounded shadow border border-gray-light`}>
@@ -79,7 +69,7 @@ export class FormFilters extends Component {
             </Button>
           </div>
         )}
-        <form onSubmit={this.handleSubmit}>
+        <form onSubmit={handleSubmit}>
           {!isDesktop && this.renderSubmitButton()}
           <RowWrapper>
             <Row>

--- a/src/components/Form/FormFilters.test.js
+++ b/src/components/Form/FormFilters.test.js
@@ -73,7 +73,8 @@ describe('FormFilters component', () => {
 
       form.simulate('submit', { preventDefault() {} });
 
-      expect(mockSubmit.mock.calls.length).toBe(0);
+      // handleSubmit is called BEFORE validation
+      expect(mockSubmit.mock.calls.length).toBe(1);
     });
   });
 

--- a/src/components/Results/index.js
+++ b/src/components/Results/index.js
@@ -5,6 +5,7 @@ import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { formValueSelector } from 'redux-form';
 import { Helmet } from 'react-helmet';
+import deepEqual from 'deep-equal';
 
 import {
   destroyFacilities,
@@ -49,11 +50,16 @@ export class Results extends Component {
     });
   };
 
+  previousValues = null;
+
   submit = values => {
     const { dispatch } = this.props;
     const { isDesktop } = this.context;
 
+    if (deepEqual(values, this.previousValues)) return;
+
     if (values.location.latLng) {
+      this.previousValues = values;
       dispatch(handleReceiveFacilities(values));
 
       if (isDesktop) {


### PR DESCRIPTION
Resolves #397 

This is not my ideal solution, but it seems to work. Ideally, when the form submits successfully, the form is reset to a "pristine" state such that we can just check the `touched` or `dirty` values to determine if any values changed and omit submitting if so. Unfortunately, there are some issues with how we are using `redux-form` that is preventing this solution but are out of the scope of this issue.

If it is worth the time, someone can go through in detail and create some issues on the backlog to refactor some of this.