### PR TITLE
Show message when no payment options are available

### DIFF
--- a/src/components/Details/DetailsPayment.js
+++ b/src/components/Details/DetailsPayment.js
@@ -19,15 +19,21 @@ const DetailsPayment = props => {
               Payment, insurance, or funding accepted
             </h2>
             <ul>
-              {((services.PAY || {}).values || []).map((value, index) => (
-                <li key={index} css={tw`flex mb-2`}>
-                  <FontAwesomeIcon
-                    icon={faCheck}
-                    css={tw`text-green mt-1 fill-current w-4 h-4 mr-2 flex-none`}
-                  />
-                  <span>{value}</span>
+              {services.PAY ? (
+                services.PAY.values.map((value, index) => (
+                  <li key={index} css={tw`flex mb-2`}>
+                    <FontAwesomeIcon
+                      icon={faCheck}
+                      css={tw`text-green mt-1 fill-current w-4 h-4 mr-2 flex-none`}
+                    />
+                    <span>{value}</span>
+                  </li>
+                ))
+              ) : (
+                <li css={tw`italic`} className="no-payment-options">
+                  Check with the facility for payment options
                 </li>
-              ))}
+              )}
             </ul>
           </div>
           <div css={tw`flex-none flex items-center bg-yellow-lighter p-4`}>

--- a/src/components/Details/DetailsPayment.test.js
+++ b/src/components/Details/DetailsPayment.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import DetailsPayment from './DetailsPayment';
+
+const testProps = {
+  services: {}
+};
+
+describe('DetailsLocation component', () => {
+  it('shows message if payment options are not available', () => {
+    const component = shallow(<DetailsPayment {...testProps} />);
+
+    expect(component.find('.no-payment-options').text()).toBe(
+      'Check with the facility for payment options'
+    );
+  });
+
+  it('shows correct number of payment options when present', () => {
+    const props = {
+      services: {
+        PAY: {
+          values: [
+            'Private health insurance',
+            'Cash or self-payment',
+            'State-financed health insurance plan other than Medicaid'
+          ]
+        }
+      }
+    };
+
+    const component = shallow(<DetailsPayment {...props} />);
+
+    expect(component.find('DetailsPayment___StyledLi').length).toBe(3);
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/18F/samhsa-prototype/issues/364

Shows message on details page when no payment options are available:
<img width="521" alt="Screen Shot 2019-10-01 at 12 51 24 PM" src="https://user-images.githubusercontent.com/1178494/65984268-633bf800-e44d-11e9-8816-ba1752266c4a.png">
