### PR TITLE
Expand filters by default if no location is set

### DIFF
--- a/src/components/Results/index.js
+++ b/src/components/Results/index.js
@@ -29,6 +29,12 @@ export class Results extends Component {
   };
 
   componentDidMount() {
+    const { hasResults, location } = this.props;
+
+    if (!hasResults && !(location || {}).latLng) {
+      this.toggleFilters();
+    }
+
     this.clearResultsIfNoLocation();
   }
 
@@ -155,6 +161,10 @@ Results.propTypes = {
   error: PropTypes.bool.isRequired,
   data: PropTypes.object.isRequired,
   hasResults: PropTypes.bool.isRequired
+};
+
+Results.contextTypes = {
+  isDesktop: PropTypes.bool
 };
 
 const selector = formValueSelector('filters');

--- a/src/components/Results/index.test.js
+++ b/src/components/Results/index.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Results } from './';
+
+const testProps = {
+  location: {},
+  dispatch: jest.fn(),
+  loading: false,
+  error: false,
+  data: {},
+  hasResults: false
+};
+
+describe('Results component', () => {
+  describe('on mobile', () => {
+    it('should expand filters by default if no location is set', () => {
+      const component = shallow(<Results {...testProps} />, {
+        context: { isDesktop: false }
+      });
+
+      expect(component.exists('Connect(ReduxForm)')).toBe(true);
+    });
+
+    it('should collapse filters by default if location is set', () => {
+      const props = {
+        ...testProps,
+        location: { latLng: {} }
+      };
+      const component = shallow(<Results {...props} />, {
+        context: { isDesktop: false }
+      });
+
+      expect(component.exists('Connect(ReduxForm)')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/18F/samhsa-prototype/issues/325

To test, on mobile, without setting a location go to `Search for treatment` in the mobile menu and observe that the filters are expanded. Go back to homepage, search for a location from the homepage as you typically would, observe that when the results are loaded the filters are collapsed.