### PR TITLE
Make card focus outline visible

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -86,11 +86,11 @@ const Card = props => {
 
   return (
     <li css={tw`bg-white shadow border-t border-gray-lighter rounded mb-10`}>
-      <div css={tw`px-6 py-4 bg-blue-light text-white rounded-t`}>
-        <Link
-          to={linkToFacility({ frid, latitude, longitude })}
-          css={tw`flex justify-between items-center -mx-2 text-white `}
-        >
+      <Link
+        to={linkToFacility({ frid, latitude, longitude })}
+        css={tw`block bg-blue-light text-white rounded-t py-4 px-6`}
+      >
+        <span css={tw`flex items-center justify-between -mx-2`}>
           <h2 css={tw`font-heading font-bold text-xl px-2`}>
             {name1}
             {name2 && (
@@ -101,8 +101,8 @@ const Card = props => {
             )}
           </h2>
           <span css={tw`flex-none px-2`}>more info ›</span>
-        </Link>
-      </div>
+        </span>
+      </Link>
       <div css={tw`flex flex-wrap -mb-4 -mx-2 p-6`}>
         <div css={tw`w-1/4 px-2`}>
           <MapStatic


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/340

**Before:**
<img width="669" alt="Screen Shot 2019-10-02 at 1 52 15 PM" src="https://user-images.githubusercontent.com/1178494/66068673-09563380-e51c-11e9-9ba4-2b809261eaf2.png">

**After:**
<img width="686" alt="Screen Shot 2019-10-02 at 1 51 43 PM" src="https://user-images.githubusercontent.com/1178494/66068667-06f3d980-e51c-11e9-91d7-7119e6e53d35.png">
