### PR TITLE
Capture Google Places API errors

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -16,6 +16,7 @@ import Home from './Home';
 import Results from './Results';
 import Details from './Details';
 import Content from './Content';
+import Error from './Error';
 import NoMatch from './NoMatch';
 import Footer from './Footer';
 
@@ -40,6 +41,7 @@ class App extends Component {
                 component={Content}
               />
               />
+              <Route path="/error" component={Error} />
               <Route component={NoMatch} />
             </Switch>
           </main>

--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { submit } from 'redux-form';
 import PlacesAutocomplete, {
   geocodeByPlaceId,
@@ -10,6 +11,7 @@ import PlacesAutocomplete, {
 import { PropTypes } from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import ReactGA from 'react-ga';
 
 import { LOCATION_WARNING } from '../../utils/warnings';
 
@@ -94,11 +96,22 @@ class Location extends Component {
   };
 
   handleError = (status, clearSuggestions) => {
+    ReactGA.event({
+      category: 'Google Places API',
+      action: 'Place details response',
+      label: 'Error',
+      value: status
+    });
+
     if (status === 'ZERO_RESULTS') {
       this.toggleShowLocationWarning(true);
+      clearSuggestions();
+      return;
     }
 
-    clearSuggestions();
+    this.props.history.push({
+      pathname: '/error'
+    });
   };
 
   render() {
@@ -186,4 +199,4 @@ Location.propTypes = {
   toggleShowWarning: PropTypes.func
 };
 
-export default connect()(Location);
+export default withRouter(connect()(Location));


### PR DESCRIPTION
Resolves https://github.com/18F/samhsa-prototype/issues/243

For all Google Places API errors: capture the status code in Google Analytics, and redirect to the `/error` page for all status codes that are not `OK` or `ZERO_RESULTS`.

Not sure how to best test that this is working as intended given the mix of dependencies (redux-form and react-places-autocomplete).