### PR TITLE
Add extra padding to location search box

### DIFF
--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -17,7 +17,7 @@ const StyledPlacesAutoComplete = styled.span`
   ${tw`block relative`}
 
   input {
-    ${tw`block w-full pr-8 text-lg`}
+    ${tw`block w-full pr-10 text-lg`}
 
     &::-webkit-input-placeholder {
       ${tw`text-gray-darkest`}


### PR DESCRIPTION
Add a small amount of additional padding so text does not flow into icon.

Before:
<img width="292" alt="Screen Shot 2019-10-02 at 3 52 12 PM" src="https://user-images.githubusercontent.com/1178494/66076915-ccdf0380-e52c-11e9-88ef-4f0d0ae3c45a.png">

After:
<img width="298" alt="Screen Shot 2019-10-02 at 3 52 18 PM" src="https://user-images.githubusercontent.com/1178494/66076905-c94b7c80-e52c-11e9-8609-0af24342ea3f.png">
