### PR TITLE
Use absolute URL for meta tags

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,6 @@
 PUBLIC_URL=$BASEURL
 REACT_APP_BRANCH=$BRANCH
+REACT_APP_SITE_DOMAIN=https://findtreatmentbeta.18f.gov
 REACT_APP_PROD_API_URL=https://findtreatment.samhsa.gov/locator/
 REACT_APP_DEV_API_URL=https://bhsis01.eagletechva.com/locator/
 REACT_APP_PROD_GA_TRACKING_ID=UA-143220884-3

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -45,11 +45,13 @@ class App extends Component {
           />
           <meta
             property="og:url"
-            content={process.env.PUBLIC_URL + this.props.location.pathname}
+            content={
+              process.env.REACT_APP_SITE_DOMAIN + this.props.location.pathname
+            }
           />
           <meta
             property="og:image"
-            content={`${process.env.PUBLIC_URL}/thumbnail.png`}
+            content={`${process.env.REACT_APP_SITE_DOMAIN}/thumbnail.png`}
           />
           <meta
             property="og:site_name"

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -93,7 +93,7 @@ class Home extends Component {
         <Helmet>
           <meta
             property="og:image"
-            content={`${process.env.PUBLIC_URL}/thumbnail-large.jpg`}
+            content={`${process.env.REACT_APP_SITE_DOMAIN}/thumbnail-large.jpg`}
           />
           <meta name="twitter:card" content="summary_large_image" />
         </Helmet>


### PR DESCRIPTION
Federalist does not expose an env var that contains the root domain name and a few of our meta tags rely on having a full absolute url vs a relative path. I've configured a new env var to refer to our prod domain name so that we can make sure the URLs are formed correctly, however for the time being I'm using `findtreatmentbeta.18f.gov`. When it comes time to launch on findtreatment.gov, this will need to be updated.