### PR TITLE
Add link to findtreatment.samhsa.gov in footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -48,6 +48,14 @@ const Footer = () => {
               <ul css={tw`mb-6`}>
                 <li>
                   <OutboundLink
+                    to="https://findtreatment.samhsa.gov"
+                    eventLabel="Link back to findtreatment.samhsa.gov from footer"
+                  >
+                    Behavioral Health Treatment Services Locator
+                  </OutboundLink>
+                </li>
+                <li>
+                  <OutboundLink
                     to="https://www.samhsa.gov/medication-assisted-treatment/practitioner-program-data/treatment-practitioner-locator"
                     eventLabel="Buprenorphine practitioners link from footer"
                   >


### PR DESCRIPTION
When we go live on FindTreatment.gov, we'll want to remove the link to the existing locator from the beta banner, so I've included it in the "Other resources" section in the footer. I've added a note in #344 to remove it from the banner before we go live. 