### PR TITLE
New production endpoint

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_DEV_API_URL=http://localhost:9011/locator/
+REACT_APP_DEV_API_URL=http://localhost:9011/locator/listing

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 PUBLIC_URL=$BASEURL
 REACT_APP_BRANCH=$BRANCH
 REACT_APP_SITE_DOMAIN=https://findtreatmentbeta.18f.gov
-REACT_APP_PROD_API_URL=https://findtreatment.samhsa.gov/locator/
-REACT_APP_DEV_API_URL=https://bhsis01.eagletechva.com/locator/
+REACT_APP_PROD_API_URL=https://kqszbed8ck.execute-api.us-east-1.amazonaws.com/prod/listing2
+REACT_APP_DEV_API_URL=https://bhsis01.eagletechva.com/locator/listing
 REACT_APP_PROD_GA_TRACKING_ID=UA-143220884-3

--- a/src/actions/facilities.js
+++ b/src/actions/facilities.js
@@ -58,7 +58,7 @@ export function handleReceiveFacilities(query) {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       data: qs.stringify(params),
-      url: '/listing'
+      url: ''
     };
 
     return API(options)

--- a/src/actions/facility.js
+++ b/src/actions/facility.js
@@ -50,7 +50,7 @@ export function handleReceiveFacility(frid, query) {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       data: qs.stringify(params),
-      url: '/listing'
+      url: ''
     };
 
     return API(options)

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -11,7 +11,7 @@ export default axios.create({
     ? process.env.REACT_APP_BRANCH === process.env.REACT_APP_PROD_BRANCH
       ? process.env.REACT_APP_PROD_API_URL
       : process.env.REACT_APP_DEV_API_URL
-    : 'http://localhost:9011/locator/',
+    : 'http://localhost:9011/locator/listing',
   responseType: 'json'
 });
 


### PR DESCRIPTION
Retargeting the `production` instance to the new API endpoint

As the beta/production endpoint names have diverged, herein we also move the final absolute endpoint into configuration and do not pass any additional paths to axios.