### PR TITLE
Increase facility filter request to 1m

### DIFF
--- a/src/actions/facility.js
+++ b/src/actions/facility.js
@@ -44,7 +44,7 @@ export function handleReceiveFacility(frid, query) {
       pageSize: 100, // Return up to 100 results in initial fetch
       sAddr: query.sAddr,
       limitType: 2, // Limit by distance
-      limitValue: 0 // Match the exact lat/lng only
+      limitValue: 1 // Return results within 1 meter
     };
 
     const options = {


### PR DESCRIPTION
Resolves #469 

When filtering by distance, the API endpoint excludes results with distances equal to the provided
limit. 

e.g. 0 meters from the queried point.

To include those results, and allow the FRID specific filtering to function, we bump our limits by 1 meter herein.