### PR TITLE
Do not rerender component if path does not change

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -35,6 +35,12 @@ class App extends Component {
     }
   };
 
+  shouldComponentUpdate(nextProps) {
+    return nextProps.location.pathname === this.props.location.pathname
+      ? false
+      : true;
+  }
+
   render() {
     const { setSRMessage } = this.props;
 


### PR DESCRIPTION
Resolves #488 

If the path (url) doesn't change, do NOT rerender the `App` component. This means that no analytics events will fire and the title and focus won't change.

I think this is the intended behavior and everything looks ok to me, but please play around and make sure this doesn't have unintended consequences.