### PR TITLE
Universally control whether external links open in a new tab, defaults to TRUE

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,7 +3,7 @@ import tw from 'tailwind.macro';
 import styled from 'styled-components/macro';
 import { PropTypes } from 'prop-types';
 import { Link } from 'react-router-dom';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from './OutboundLink';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck, faPhone } from '@fortawesome/free-solid-svg-icons';
 
@@ -134,8 +134,6 @@ const Card = props => {
               <OutboundLink
                 eventLabel="Facility website link from card"
                 to={website}
-                target="_blank"
-                rel="noopener noreferrer"
                 css={tw`ml-6`}
               >
                 {removeHttp(website).toLowerCase()}
@@ -145,8 +143,6 @@ const Card = props => {
           <OutboundLink
             eventLabel="Facility address link from card"
             to={googleMapUrl(address)}
-            target="_blank"
-            rel="noopener noreferrer"
             css={tw`block mb-2 ml-6`}
           >
             <address css={tw`not-italic text-gray`}>

--- a/src/components/Details/DetailsLocation.js
+++ b/src/components/Details/DetailsLocation.js
@@ -8,7 +8,7 @@ import {
   faExclamationTriangle,
   faExternalLinkAlt
 } from '@fortawesome/free-solid-svg-icons';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 import { formatAddress, formatMiles, googleMapUrl } from '../../utils/misc';
 
@@ -81,7 +81,6 @@ const DetailsLocation = props => {
                   eventLabel="Driving directions link from details"
                   to={googleMapUrl(address)}
                   css={tw`w-full`}
-                  target="_blank"
                 >
                   <FontAwesomeIcon icon={faExternalLinkAlt} css={tw`mr-2`} />
                   Get directions

--- a/src/components/Details/index.js
+++ b/src/components/Details/index.js
@@ -143,7 +143,6 @@ export class Details extends Component {
                   <OutboundLink
                     eventLabel="Facility website link from card"
                     to={website}
-                    rel="noopener noreferrer"
                   >
                     {removeHttp(website)}
                   </OutboundLink>

--- a/src/components/Details/index.js
+++ b/src/components/Details/index.js
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFlag, faPhone } from '@fortawesome/free-solid-svg-icons';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 import { Helmet } from 'react-helmet';
 import Masonry from 'react-masonry-css';
 
@@ -143,7 +143,6 @@ export class Details extends Component {
                   <OutboundLink
                     eventLabel="Facility website link from card"
                     to={website}
-                    target="_blank"
                     rel="noopener noreferrer"
                   >
                     {removeHttp(website)}

--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -4,7 +4,7 @@ import tw from 'tailwind.macro';
 import 'styled-components/macro';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPhone } from '@fortawesome/free-solid-svg-icons';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from './OutboundLink';
 import { Helmet } from 'react-helmet';
 
 import { HELPLINE_LINK, HELPLINE_TEXT } from '../utils/constants';

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 import tw from 'tailwind.macro';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from './OutboundLink';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { ReactComponent as LogoSAMHSA } from '../images/logo-samhsa.svg';

--- a/src/components/Header/HeaderBeta.js
+++ b/src/components/Header/HeaderBeta.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import tw from 'tailwind.macro';
 import 'styled-components/macro';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 const HeaderBeta = () => {
   return (

--- a/src/components/Header/HeaderHelpLine.js
+++ b/src/components/Header/HeaderHelpLine.js
@@ -3,7 +3,7 @@ import tw from 'tailwind.macro';
 import 'styled-components/macro';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 import { HELPLINE_LINK, HELPLINE_TEXT } from '../../utils/constants';
 

--- a/src/components/Map/MapStatic.js
+++ b/src/components/Map/MapStatic.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import 'styled-components/macro';
 import tw from 'tailwind.macro';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 import placeholder from '../../images/placeholder.png';
 import { GOOGLE_MAP_STATIC_URL } from '../../utils/constants';
@@ -25,8 +25,6 @@ export class MapStatic extends Component {
       <OutboundLink
         eventLabel="Driving directions link from card thumbnail image"
         to={googleMapUrl(address)}
-        target="_blank"
-        rel="noopener noreferrer"
         aria-label={`Driving directions for ${name1}`}
       >
         <img

--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OutboundLink as OL } from 'react-ga';
+
+const mergeProps = ({ targetBlank, ...rest }) =>
+  targetBlank && !rest.to.startsWith('tel:') && !rest.to.startsWith('email:')
+    ? {
+        ...rest,
+        target: '_blank',
+        rel: 'noopener noreferrer'
+      }
+    : rest;
+
+const OutboundLink = props => <OL {...mergeProps(props)} />;
+
+OutboundLink.propTypes = {
+  ...OL.propTypes,
+  targetBlank: PropTypes.bool
+};
+
+OutboundLink.defaultProps = {
+  targetBlank: true
+};
+
+export default OutboundLink;

--- a/src/components/OutboundLink.test.js
+++ b/src/components/OutboundLink.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OutboundLink as OL } from 'react-ga';
+import OutboundLink from './OutboundLink';
+
+const ATTRS_SELECTOR = 'a[target="_blank"][rel="noopener noreferrer"]';
+
+const defaultProps = {
+  to: '',
+  eventLabel: ''
+};
+
+describe.only('Outbound Link component', () => {
+  it('returns a Google Analytics Outbound Link component', () => {
+    const wrapper = shallow(<OutboundLink {...defaultProps} />);
+    expect(wrapper.is(OL)).toEqual(true);
+  });
+
+  it('sets new tab attributes when targetBlank is true', () => {
+    const props = {
+      ...defaultProps,
+      targetBlank: true
+    };
+
+    const wrapper = shallow(<OutboundLink {...props} />).dive();
+    expect(wrapper.exists(ATTRS_SELECTOR)).toEqual(true);
+  });
+
+  it('targetBlank is true by default', () => {
+    const wrapper = shallow(<OutboundLink {...defaultProps} />).dive();
+    expect(wrapper.exists(ATTRS_SELECTOR)).toEqual(true);
+  });
+
+  it('does not set new tab attributes for telephone links', () => {
+    const props = {
+      ...defaultProps,
+      to: 'tel:'
+    };
+
+    const wrapper = shallow(<OutboundLink {...props} />).dive();
+    expect(wrapper.exists(ATTRS_SELECTOR)).toEqual(false);
+  });
+
+  it('does not set new tab attributes for email links', () => {
+    const props = {
+      ...defaultProps,
+      to: 'email:'
+    };
+
+    const wrapper = shallow(<OutboundLink {...props} />).dive();
+    expect(wrapper.exists(ATTRS_SELECTOR)).toEqual(false);
+  });
+
+  it('does not set new tab attributes when targetBlank is false', () => {
+    const props = {
+      ...defaultProps,
+      targetBlank: false
+    };
+
+    const wrapper = shallow(<OutboundLink {...props} />).dive();
+    expect(wrapper.exists(ATTRS_SELECTOR)).toEqual(false);
+  });
+});

--- a/src/components/Results/NoLocation.js
+++ b/src/components/Results/NoLocation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import tw from 'tailwind.macro';
 import 'styled-components/macro';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 import { HELPLINE_LINK, HELPLINE_TEXT } from '../../utils/constants';
 

--- a/src/components/Results/NoResults.js
+++ b/src/components/Results/NoResults.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import tw from 'tailwind.macro';
 import 'styled-components/macro';
-import { OutboundLink } from 'react-ga';
+import OutboundLink from '../OutboundLink';
 
 import { HELPLINE_LINK, HELPLINE_TEXT } from '../../utils/constants';
 


### PR DESCRIPTION
Resolves #494 

This provides a one stop shop for controlling whether our external (or outbound) links open in a new tab. The current default is set to `true`. Email (`email:`) and telephone (`tel:`) links are excluded and will not receive the attributes to open in a new tab.

This just wraps the existing `OutboundLink` component provided by Google Analytics so that functionality should remain unchanged.

Also adds `rel="nooponer noreferrer"` attribute to the link.