### PR TITLE
Truncate long urls on details page

### DIFF
--- a/src/components/Details/index.js
+++ b/src/components/Details/index.js
@@ -140,12 +140,14 @@ export class Details extends Component {
                   {name2 && ` ${name2}`}
                 </h1>
                 {website !== 'http://' && (
-                  <OutboundLink
-                    eventLabel="Facility website link from card"
-                    to={website}
-                  >
-                    {removeHttp(website)}
-                  </OutboundLink>
+                  <div css={tw`truncate`}>
+                    <OutboundLink
+                      eventLabel="Facility website link from card"
+                      to={website}
+                    >
+                      {removeHttp(website)}
+                    </OutboundLink>
+                  </div>
                 )}
               </div>
               <div


### PR DESCRIPTION
Fixes https://github.com/18F/samhsa-prototype/issues/519

Uses tailwind's `truncate` CSS class https://tailwindcss.com/docs/word-break/#truncate