### PR TITLE
Don't send autocomplete errors for no-results

### DIFF
--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -96,19 +96,17 @@ class Location extends Component {
   };
 
   handleError = (status, clearSuggestions) => {
+    if (status === 'ZERO_RESULTS') {
+      this.toggleShowLocationWarning(true);
+      clearSuggestions();
+      return;
+    }
     ReactGA.event({
       category: 'errors',
       action: 'autocomplete API',
       label: 'Error',
       value: status
     });
-
-    if (status === 'ZERO_RESULTS') {
-      this.toggleShowLocationWarning(true);
-      clearSuggestions();
-      return;
-    }
-
     this.props.history.push({
       pathname: '/error'
     });


### PR DESCRIPTION
We should only report errors which are not already handled by our Autocomplete implementation.