### PR TITLE
Add canonical url

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -88,6 +88,12 @@ class App extends Component {
             property="og:site_name"
             content={process.env.REACT_APP_SITE_TITLE}
           />
+          <link
+            rel="canonical"
+            href={
+              process.env.REACT_APP_SITE_DOMAIN + this.props.location.pathname
+            }
+          />
         </Helmet>
         <GlobalStyle />
         <div css={tw`overflow-hidden`} id={TOP_ID} tabIndex="-1">


### PR DESCRIPTION
It appears that the https://www.findtreatment.gov site was crawled but not indexed due to the following error.

![Screen Shot 2019-10-30 at 7 18 24 AM](https://user-images.githubusercontent.com/6662371/67865982-7b9f4100-fae5-11e9-8d9d-2d47e0bc60c0.png)

Per https://support.google.com/webmasters/answer/7440203#duplicate_page_without_canonical_tag
https://support.google.com/webmasters/answer/139066

Add the "canonical url" to each page.